### PR TITLE
[DA] CommonView → BaseView로 네이밍 수정 및 메소드 추가

### DIFF
--- a/Projects/App/Sources/Common/View/BaseView.swift
+++ b/Projects/App/Sources/Common/View/BaseView.swift
@@ -1,5 +1,5 @@
 //
-//  CommonView.swift
+//  BaseView.swift
 //  GGiriGGiri
 //
 //  Created by 안상희 on 2022/07/09.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class CommonView: UIView {
+class BaseView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Projects/App/Sources/Common/View/BaseView.swift
+++ b/Projects/App/Sources/Common/View/BaseView.swift
@@ -13,16 +13,20 @@ class BaseView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        setUI()
+        setLayout()
+        configure()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         
-        setUI()
+        setLayout()
+        configure()
     }
     
-    func setUI() {
+    func setLayout() { }
+    
+    func configure() {
         backgroundColor = .white
     }
 }

--- a/Projects/App/Sources/Common/View/CommonHeaderView.swift
+++ b/Projects/App/Sources/Common/View/CommonHeaderView.swift
@@ -6,8 +6,9 @@
 //  Copyright © 2022 dvHuni. All rights reserved.
 //
 
-import SnapKit
 import UIKit
+
+import SnapKit
 
 final class CommonHeaderView: UICollectionReusableView {
     
@@ -25,6 +26,8 @@ final class CommonHeaderView: UICollectionReusableView {
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        
+        configure()
     }
     
     private func configure() {

--- a/Projects/App/Sources/Main/View/CategoryCollectionViewCell.swift
+++ b/Projects/App/Sources/Main/View/CategoryCollectionViewCell.swift
@@ -6,8 +6,9 @@
 //  Copyright © 2022 dvHuni. All rights reserved.
 //
 
-import SnapKit
 import UIKit
+
+import SnapKit
 
 final class CategoryCollectionViewCell: UICollectionViewCell {
     
@@ -25,14 +26,16 @@ final class CategoryCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        configure()
+        setLayout()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        
+        setLayout()
     }
     
-    private func configure() {
+    private func setLayout() {
         contentView.addSubview(nameLabel)
         
         nameLabel.snp.makeConstraints {

--- a/Projects/App/Sources/Main/View/GifticonDeadLineCollectionViewCell.swift
+++ b/Projects/App/Sources/Main/View/GifticonDeadLineCollectionViewCell.swift
@@ -51,14 +51,16 @@ final class GifticonDeadLineCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        configure()
+        setLayout()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+        
+        setLayout()
     }
     
-    private func configure() {
+    private func setLayout() {
         contentView.addSubview(verticalStackView)
         
         verticalStackView.snp.makeConstraints {

--- a/Projects/App/Sources/Main/View/MainView.swift
+++ b/Projects/App/Sources/Main/View/MainView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 import SnapKit
 
-final class MainView: CommonView {
+final class MainView: BaseView {
     
     override func setUI() {
         addSubview(collectionView)

--- a/Projects/App/Sources/Main/View/MainView.swift
+++ b/Projects/App/Sources/Main/View/MainView.swift
@@ -12,7 +12,9 @@ import SnapKit
 
 final class MainView: BaseView {
     
-    override func setUI() {
+    override func setLayout() {
+        super.setLayout()
+        
         addSubview(collectionView)
         
         collectionView.snp.makeConstraints {

--- a/Projects/App/Sources/Register/ImagePickerViewController.swift
+++ b/Projects/App/Sources/Register/ImagePickerViewController.swift
@@ -17,13 +17,11 @@ final class ImagePickerViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+    
         configure()
     }
     
     private func configure() {
-        view.backgroundColor = .white
-        
         configureNavigationBar()
 
         delegate.imageCollectionViewCellDelegate = self

--- a/Projects/App/Sources/Register/RegisterGifticonTableViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonTableViewController.swift
@@ -17,8 +17,6 @@ final class RegisterGifticonTableViewController: UITableViewController {
     }
     
     private func configure() {
-        view.backgroundColor = .white
-        
         configureNavigationBar()
     }
     

--- a/Projects/App/Sources/Register/View/ImageCollectionViewCell.swift
+++ b/Projects/App/Sources/Register/View/ImageCollectionViewCell.swift
@@ -35,12 +35,14 @@ final class ImageCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        setLayout()
         configure()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         
+        setLayout()
         configure()
     }
     
@@ -54,10 +56,9 @@ final class ImageCollectionViewCell: UICollectionViewCell {
         }
     }
     
-    private func configure() {
+    private func setLayout() {
         imageView.addSubview(checkmarkImageView)
         
-        checkmarkImageView.isHidden = true
         checkmarkImageView.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
@@ -67,5 +68,9 @@ final class ImageCollectionViewCell: UICollectionViewCell {
         imageView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
+    }
+    
+    private func configure() {
+        checkmarkImageView.isHidden = true
     }
 }

--- a/Projects/App/Sources/Register/View/ImagePickerView.swift
+++ b/Projects/App/Sources/Register/View/ImagePickerView.swift
@@ -12,8 +12,8 @@ import SnapKit
 
 final class ImagePickerView: BaseView {
     
-    override func setUI() {
-        backgroundColor = .white
+    override func setLayout() {
+        super.setLayout()
         
         addSubview(collectionView)
         

--- a/Projects/App/Sources/Register/View/ImagePickerView.swift
+++ b/Projects/App/Sources/Register/View/ImagePickerView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 import SnapKit
 
-final class ImagePickerView: CommonView {
+final class ImagePickerView: BaseView {
     
     override func setUI() {
         backgroundColor = .white

--- a/Projects/App/Sources/Register/View/RegisterGifticonView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 final class RegisterGifticonView: BaseView {
     
-    override func setUI() {
-        backgroundColor = .white
+    override func setLayout() {
+        super.setLayout()
     }
 }

--- a/Projects/App/Sources/Register/View/RegisterGifticonView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-final class RegisterGifticonView: CommonView {
+final class RegisterGifticonView: BaseView {
     
     override func setUI() {
         backgroundColor = .white


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : https://github.com/mash-up-kr/GGiriGGiri_iOS/issues/52


# 변경사항
- CommonView는 대부분의 UIView들이 상속하여 사용하기 때문에 `CommonView`보다는 `BaseView`라는 네이밍이 더 낫다는 판단 하에 네이밍 수정
- 대부분의 뷰에서 사용하는 `setUI`, `configure` 메서드에 대한 확실한 경계가 없어서 이를 확실하게 정함

### setLayout()
- UI 컴포넌트들을 화면에 **추가** 및 **배치**할 때 사용하는 메서드
- ex) addSubview, constraint 추가 등

### configure()
- 뷰를 **세팅**하는 메서드
- ex) color, radius, setTitle 등