### PR TITLE
[D2] InputField, InputView 컴포넌트 작성

### DIFF
--- a/Projects/DesignSystem/Sources/Component/Extension/UIStackView+.swift
+++ b/Projects/DesignSystem/Sources/Component/Extension/UIStackView+.swift
@@ -1,0 +1,17 @@
+//
+//  UIStackView+.swift
+//  DesignSystem
+//
+//  Created by AhnSangHoon on 2022/07/22.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+extension UIStackView {
+    func addArrangedSubviews(_ views: UIView...) {
+        views.forEach {
+            addArrangedSubview($0)
+        }
+    }
+}

--- a/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
+++ b/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
@@ -10,6 +10,7 @@ import UIKit
 
 import SnapKit
 import RxSwift
+import RxRelay
 
 /// DDIP DesignSystem InputField
 public final class DDIPInputField: UIView {
@@ -41,9 +42,11 @@ public final class DDIPInputField: UIView {
     
     private var disposeBag = DisposeBag()
     
+    let state = PublishRelay<DDIPInputField.State>()
+    
     // MARK: - Property Observers
     
-    private var state: State = .normal {
+    private var _state: State = .normal {
         didSet {
             update(which: .state)
         }
@@ -118,7 +121,9 @@ extension DDIPInputField {
             .withUnretained(self)
             .skip(1)
             .subscribe(onNext: { (owner, text) in
-                owner.update(state: owner.check(text))
+                let state = owner.check(text)
+                owner.update(state: state)
+                owner.state.accept(state)
             })
             .disposed(by: disposeBag)
         
@@ -164,7 +169,7 @@ extension DDIPInputField {
     }
     
     private func updateColor() {
-        switch state {
+        switch _state {
         case .normal:
             wrapper.layer.borderColor = UIColor.clear.cgColor
             textfield.textColor = .designSystem(.neutralBlack)
@@ -187,7 +192,7 @@ extension DDIPInputField {
 
 extension DDIPInputField {
     public func update(state: State) {
-        self.state = state
+        _state = state
     }
     
     public func update(placeholder: String?) {

--- a/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
+++ b/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
@@ -121,6 +121,14 @@ extension DDIPInputField {
                 owner.update(state: owner.check(text))
             })
             .disposed(by: disposeBag)
+        
+        textfield.rx.controlEvent(.editingDidEnd)
+            .withUnretained(self)
+            .subscribe(onNext: { (owner, _) in
+                owner.update(which: .state)
+            })
+            .disposed(by: disposeBag)
+        
     }
     
     private func check(_ text: String?) -> State {

--- a/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
+++ b/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
@@ -55,6 +55,12 @@ public final class DDIPInputField: UIView {
         }
     }
     
+    private var text: String? {
+        didSet {
+            update(which: .text)
+        }
+    }
+    
     private var condition: ((String?) -> (Bool))? = nil {
         didSet {
             bind()
@@ -135,6 +141,7 @@ extension DDIPInputField {
     private enum Update {
         case state
         case placeholder
+        case text
     }
     
     private func update(which: Update) {
@@ -143,6 +150,8 @@ extension DDIPInputField {
             updateColor()
         case .placeholder:
             updatePlaceHolder()
+        case .text:
+            updateText()
         }
     }
     
@@ -159,6 +168,10 @@ extension DDIPInputField {
     
     private func updatePlaceHolder() {
         textfield.placeholder = placeholder
+    }
+    
+    private func updateText() {
+        textfield.text = text
     }
 }
 
@@ -180,5 +193,9 @@ extension DDIPInputField {
         }
 
         self.condition = condition
+    }
+    
+    public func update(text: String?) {
+        self.text = text
     }
 }

--- a/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
+++ b/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
@@ -1,0 +1,184 @@
+//
+//  DDIPInputField.swift
+//  DesignSystem
+//
+//  Created by AhnSangHoon on 2022/07/20.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+import SnapKit
+import RxSwift
+
+/// DDIP DesignSystem InputField
+public final class DDIPInputField: UIView {
+    public enum State {
+        case normal
+        case error
+    }
+    
+    // MARK: - UI Property
+    
+    private let wrapper: UIView = {
+        let view = UIView()
+        view.layer.cornerRadius = 12
+        view.clipsToBounds = true
+        view.backgroundColor = .designSystem(.neutralGray100)
+        view.layer.borderColor = UIColor.clear.cgColor
+        view.layer.borderWidth = 1
+        return view
+    }()
+    
+    private let textfield: UITextField = {
+        let textfield = UITextField()
+        textfield.font = .designSystem(.pretendard, family: .regular, size: ._14)
+        textfield.backgroundColor = .clear
+        return textfield
+    }()
+    
+    // MARK: - Binding Property
+    
+    private var disposeBag = DisposeBag()
+    
+    // MARK: - Property Observers
+    
+    private var state: State = .normal {
+        didSet {
+            update(which: .state)
+        }
+    }
+    
+    private var placeholder: String? {
+        didSet {
+            update(which: .placeholder)
+        }
+    }
+    
+    private var condition: ((String?) -> (Bool))? = nil {
+        didSet {
+            bind()
+        }
+    }
+    
+    // MARK: - Initializer
+    
+    public init(placeholder: String? = nil, condition: ((String?) -> (Bool))? = nil) {
+        super.init(frame: .zero)
+        layout()
+        bind()
+        
+        update(placeholder: placeholder)
+        update(condition: condition)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Layout
+
+extension DDIPInputField {
+    private func layout() {
+        addSubview(wrapper)
+        snp.makeConstraints {
+            $0.height.equalTo(54)
+        }
+        wrapper.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        wrapper.addSubview(textfield)
+        textfield.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview().inset(17)
+            $0.left.right.equalToSuperview().inset(20)
+        }
+    }
+}
+
+// MARK: - Binding
+
+extension DDIPInputField {
+    private func bind() {
+        disposeBag = DisposeBag()
+        
+        if condition != nil {
+            bindCheck()
+        }
+    }
+    
+    private func bindCheck() {
+        textfield.rx.text
+            .withUnretained(self)
+            .skip(1)
+            .subscribe(onNext: { (owner, text) in
+                owner.update(state: owner.check(text))
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func check(_ text: String?) -> State {
+        guard let condition = condition else {
+            return .error
+        }
+        if condition(text) {
+            return .normal
+        } else {
+            return .error
+        }
+    }
+}
+
+// MARK: - Private Update
+
+extension DDIPInputField {
+    private enum Update {
+        case state
+        case placeholder
+    }
+    
+    private func update(which: Update) {
+        switch which {
+        case .state:
+            updateColor()
+        case .placeholder:
+            updatePlaceHolder()
+        }
+    }
+    
+    private func updateColor() {
+        switch state {
+        case .normal:
+            wrapper.layer.borderColor = UIColor.clear.cgColor
+            textfield.textColor = .designSystem(.neutralBlack)
+        case .error:
+            textfield.textColor = .designSystem(.dangerRaspberry)
+            wrapper.layer.borderColor = UIColor.designSystem(.dangerRaspberry)?.cgColor
+        }
+    }
+    
+    private func updatePlaceHolder() {
+        textfield.placeholder = placeholder
+    }
+}
+
+// MARK: - Public Update
+
+extension DDIPInputField {
+    public func update(state: State) {
+        self.state = state
+    }
+    
+    public func update(placeholder: String?) {
+        self.placeholder = placeholder
+    }
+    
+    public func update(condition: ((String?) -> Bool)?) {
+        guard let condition = condition else {
+            disposeBag = DisposeBag()
+            return
+        }
+
+        self.condition = condition
+    }
+}

--- a/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
+++ b/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
@@ -173,8 +173,8 @@ extension DDIPInputField {
             wrapper.layer.borderColor = UIColor.clear.cgColor
             textfield.textColor = .designSystem(.neutralBlack)
         case .error:
-            textfield.textColor = .designSystem(.dangerRaspberry)
             wrapper.layer.borderColor = UIColor.designSystem(.dangerRaspberry)?.cgColor
+            textfield.textColor = .designSystem(.dangerRaspberry)
         }
     }
     

--- a/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
+++ b/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
@@ -142,9 +142,8 @@ extension DDIPInputField {
         }
         if condition(text) {
             return .normal
-        } else {
-            return .error
-        }
+        } 
+        return .error
     }
 }
 

--- a/Projects/DesignSystem/Sources/Component/InputView/DDIPInputView.swift
+++ b/Projects/DesignSystem/Sources/Component/InputView/DDIPInputView.swift
@@ -153,7 +153,6 @@ extension DDIPInputView {
     private func bindActionButton() {
         guard action != nil else { return }
         actionButton.rx.tap
-            .debug()
             .subscribe(onNext: { [weak self] in
                 self?.action?()
             })

--- a/Projects/DesignSystem/Sources/Component/InputView/DDIPInputView.swift
+++ b/Projects/DesignSystem/Sources/Component/InputView/DDIPInputView.swift
@@ -1,0 +1,268 @@
+//
+//  DDIPInputView.swift
+//  DesignSystem
+//
+//  Created by AhnSangHoon on 2022/07/22.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+import RxSwift
+
+public final class DDIPInputView: UIView {
+    public enum InputType {
+        case text
+        case custom(action: (() -> ()))
+    }
+    
+    // MARK: - UI Property
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        return stackView
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .designSystem(.pretendard, family: .regular, size: ._14)
+        return label
+    }()
+    
+    private lazy var inputField: DDIPInputField = {
+        let inputField = DDIPInputField(
+            placeholder: placeholder,
+            condition: condition
+        )
+        return inputField
+    }()
+    
+    private let helperTextLabel: UILabel = {
+        let label = UILabel()
+        label.font = .designSystem(.pretendard, family: .regular, size: ._14)
+        return label
+    }()
+    
+    private let actionButton = UIButton()
+    
+    // MARK: - Binding Property
+    
+    private var disposeBag = DisposeBag()
+    
+    // MARK: - Property Observers
+    
+    private var inputType: InputType = .text {
+        didSet {
+            update(which: .inputType)
+        }
+    }
+    
+    private var title: String? {
+        didSet {
+            update(which: .title)
+        }
+    }
+    
+    private var placeholder: String? {
+        didSet {
+            update(which: .placeholder)
+        }
+    }
+    
+    private var _text: String? {
+        didSet {
+            update(which: .text)
+        }
+    }
+    
+    private var helperText: String? {
+        didSet {
+            update(which: .text)
+        }
+    }
+    
+    private var condition: ((String?) -> (Bool))? = nil {
+        didSet {
+            update(which: .condition)
+        }
+    }
+    
+    private var action: (() -> ())? = nil {
+        didSet {
+            bind()
+        }
+    }
+    
+    private var _state: DDIPInputField.State = .normal {
+        didSet {
+            update(which: .state)
+        }
+    }
+    
+    // MARK: - Initializer
+    
+    public convenience init(inputType: InputType, title: String, placeholder: String) {
+        self.init(inputType: inputType, title: title, placeholder: placeholder, condition: nil)
+    }
+    
+    public init(inputType: InputType = .text ,title: String, placeholder: String, condition: ((String?) -> (Bool))? = nil) {
+        super.init(frame: .zero)
+        layout()
+        bind()
+        
+        update(inputType: inputType)
+        update(title: title)
+        update(placeholder: placeholder)
+        update(condition: condition)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Layout
+
+extension DDIPInputView: AddViewsable {
+    private func layout() {
+        addSubViews([stackView, actionButton])
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        actionButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        stackView.addArrangedSubviews(titleLabel, inputField, helperTextLabel)
+        stackView.setCustomSpacing(8, after: titleLabel)
+        stackView.setCustomSpacing(4, after: helperTextLabel)
+    }
+}
+
+// MARK: - Binding
+
+extension DDIPInputView {
+    private func bind() {
+        disposeBag = DisposeBag()
+        
+        bindActionButton()
+    }
+    
+    private func bindActionButton() {
+        guard action != nil else { return }
+        actionButton.rx.tap
+            .debug()
+            .subscribe(onNext: { [weak self] in
+                self?.action?()
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+
+// MARK: - Private Update
+
+extension DDIPInputView {
+    private enum Update {
+        case inputType
+        case title
+        case placeholder
+        case text
+        case condition
+        case state
+    }
+    
+    private func update(which: Update) {
+        switch which {
+        case .inputType:
+            updateInputType()
+        case .title:
+            updateTitle()
+        case .placeholder:
+            updatePlaceholder()
+        case .text:
+            updateText()
+        case .condition:
+            updateCondition()
+        case .state:
+            updateState()
+        }
+    }
+    
+    private func updateInputType() {
+        switch inputType {
+        case .text:
+            actionButton.isUserInteractionEnabled = false
+            self.action = nil
+        case let .custom(action):
+            actionButton.isUserInteractionEnabled = true
+            self.action = action
+        }
+    }
+    
+    private func updateTitle() {
+        titleLabel.text = title
+    }
+    
+    private func updatePlaceholder() {
+        inputField.update(placeholder: placeholder)
+    }
+    
+    private func updateText() {
+        inputField.update(text: _text)
+    }
+    
+    private func updateCondition() {
+        inputField.update(condition: condition)
+    }
+    
+    private func updateState() {
+        inputField.update(state: _state)
+    }
+}
+
+// MARK: - Public Update
+
+extension DDIPInputView {
+    public func update(title: String?) {
+        self.title = title
+    }
+    
+    public func update(placeholder: String?) {
+        self.placeholder = placeholder
+    }
+    
+    public func update(text: String?) {
+        _text = text
+    }
+    
+    public func update(helperText: String?) {
+        self.helperText = helperText
+    }
+    
+    public func update(condition: ((String?) -> Bool)?) {
+        guard let condition = condition else { return }
+
+        self.condition = condition
+    }
+    
+    public func update(inputType: InputType) {
+        self.inputType = inputType
+    }
+    
+    public func update(state: DDIPInputField.State) {
+        self._state = state
+    }
+}
+
+// MARK: - Public
+
+extension DDIPInputView {
+    public func text() -> String? {
+        _text
+    }
+    public func state() -> DDIPInputField.State {
+        _state
+    }
+}

--- a/Projects/DesignSystem/Sources/Component/InputView/DDIPInputView.swift
+++ b/Projects/DesignSystem/Sources/Component/InputView/DDIPInputView.swift
@@ -78,7 +78,7 @@ public final class DDIPInputView: UIView {
     
     private var helperText: String? {
         didSet {
-            update(which: .text)
+            update(which: .helperText)
         }
     }
     
@@ -147,6 +147,7 @@ extension DDIPInputView {
         disposeBag = DisposeBag()
         
         bindActionButton()
+        bindInputFieldState()
     }
     
     private func bindActionButton() {
@@ -155,6 +156,16 @@ extension DDIPInputView {
             .debug()
             .subscribe(onNext: { [weak self] in
                 self?.action?()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func bindInputFieldState() {
+        inputField.state
+            .subscribe(onNext: { [weak self] in
+                self?.update(state: $0)
+                self?.update(which: .helperTextColor)
+                self?.update(which: .helperTextVisible)
             })
             .disposed(by: disposeBag)
     }
@@ -169,6 +180,9 @@ extension DDIPInputView {
         case title
         case placeholder
         case text
+        case helperText
+        case helperTextColor
+        case helperTextVisible
         case condition
         case state
     }
@@ -183,6 +197,12 @@ extension DDIPInputView {
             updatePlaceholder()
         case .text:
             updateText()
+        case .helperText:
+            updateHelperText()
+        case .helperTextColor:
+            updateHelperTextColor()
+        case .helperTextVisible:
+            updateHelperTextVisible()
         case .condition:
             updateCondition()
         case .state:
@@ -211,6 +231,28 @@ extension DDIPInputView {
     
     private func updateText() {
         inputField.update(text: _text)
+    }
+    
+    private func updateHelperText() {
+        helperTextLabel.text = helperText
+    }
+    
+    private func updateHelperTextColor() {
+        switch _state {
+        case .normal:
+            helperTextLabel.textColor = .designSystem(.neutralBlack)
+        case .error:
+            helperTextLabel.textColor = .designSystem(.dangerRaspberry)
+        }
+    }
+    
+    private func updateHelperTextVisible() {
+        switch _state {
+        case .normal:
+            helperTextLabel.isHidden = true
+        case .error:
+            helperTextLabel.isHidden = false
+        }
     }
     
     private func updateCondition() {


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : #5


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* UIComponent 중 `input field`/ input field와 title, helpertext를 wrapping 한 `input view`를 만들었습니다.
* helpertext는 [라인 디자인 시스템](https://designsystem.line.me/LDSM/components/input-ex-ko/)을 참고하였습니다.
* component를 노출하기 위해서 임시로 화면을 만들었습니다.
* 사용예시
```swift
DDIPInputField(placeholder: "인풋필드(조건 없음)"),
DDIPInputField(
    placeholder: "인풋필드(조건 있음, 4글자 미만시 경고",
    condition: { text in
        text?.count ?? .zero > 3
    }),
DDIPInputView(title: "인풋뷰", placeholder: "타이틀과 플레이스홀더"),
DDIPInputView(
    title: "인풋뷰",
    placeholder: "타이틀과 플레이스홀더 (조건 있음, 4글자 미만시 경고)",
    condition: { text in
        text?.count ?? .zero > 3
    }),
DDIPInputView(
    inputType: .custom(
        action: { [weak self] in
            let alertController = UIAlertController(title: "이것은", message: "테스트", preferredStyle: .alert)
            let action = UIAlertAction(title: "닫기", style: .default)
            alertController.addAction(action)
            self?.present(alertController, animated: true)
        }),
    title: "인풋뷰 터치시",
    placeholder: "알럿 노출됨"
)
```

### 미리보기
<!-- 작업 전/후 스크린샷으로 표현하기 어려울 경우 영상을 첨부합니다. -->

작업 후


https://user-images.githubusercontent.com/39300449/180604357-4e74dc5e-5320-4e81-a1e6-471062ab9b64.mp4
