### PR TITLE
[DA] DDipToastView 표시하는 로직 공통화

### DIFF
--- a/Projects/App/Sources/Common/View/ToastView.swift
+++ b/Projects/App/Sources/Common/View/ToastView.swift
@@ -21,7 +21,7 @@ final class ToastView {
         toastView.setDescriptionLabel(style)
         toastView.setIconImageView(image)
         
-        dimView.backgroundColor = UIColor.black.withAlphaComponent(0.25)
+        dimView.backgroundColor = .designSystem(.neutralBlack)?.withAlphaComponent(0.25)
         dimView.addSubview(toastView)
         wrapperView.addSubview(dimView)
         

--- a/Projects/App/Sources/Common/View/ToastView.swift
+++ b/Projects/App/Sources/Common/View/ToastView.swift
@@ -1,0 +1,71 @@
+//
+//  ToastView.swift
+//  GGiriGGiri
+//
+//  Created by 안상희 on 2022/08/05.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+import DesignSystem
+
+final class ToastView {
+    private let toastView = DDIPToastView()
+    private let wrapperView = UIView()
+    private let dimView = UIView()
+    
+    func configureToastView(with view: UIView, style: DDIPToastView.ToastViewOptions, image: DDIPAsset.name) {
+        toastView.setTitleLabel(style)
+        toastView.setDescriptionLabel(style)
+        toastView.setIconImageView(image)
+        
+        dimView.backgroundColor = UIColor.black.withAlphaComponent(0.25)
+        dimView.addSubview(toastView)
+        wrapperView.addSubview(dimView)
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissPopupView(_:)))
+        wrapperView.addGestureRecognizer(tapGesture)
+        wrapperView.isUserInteractionEnabled = true
+        
+        view.addSubview(wrapperView)
+        wrapperView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        dimView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        toastView.snp.makeConstraints {
+            $0.width.equalTo(289)
+            $0.height.equalTo(295)
+            $0.centerX.centerY.equalToSuperview()
+        }
+
+        toastView.alpha = 0
+    }
+    
+    func showToastView(with view: UIView) {
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now()) {
+            UIView.transition(with: view, duration: 0.3, options: [.curveEaseInOut], animations: {
+                self.toastView.alpha = 1
+            }, completion: nil)
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 4) {
+            UIView.transition(with: view, duration: 0.3, options: [.curveEaseInOut], animations: {
+                self.toastView.alpha = 0
+            }, completion: { _ in
+                self.dimView.removeFromSuperview()
+                self.wrapperView.removeFromSuperview()
+            })
+        }
+    }
+    
+    @objc private func dismissPopupView(_ gesture: UITapGestureRecognizer) {
+        toastView.alpha = 0
+        dimView.removeFromSuperview()
+        wrapperView.removeFromSuperview()
+    }
+}

--- a/Projects/App/Sources/Common/View/ToastView.swift
+++ b/Projects/App/Sources/Common/View/ToastView.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 import DesignSystem
+import SnapKit
 
 final class ToastView {
     private let toastView = DDIPToastView()

--- a/Projects/App/Sources/Result/ResultViewController.swift
+++ b/Projects/App/Sources/Result/ResultViewController.swift
@@ -82,58 +82,9 @@ extension ResultViewController: ResultViewButtonDelegate {
     }
     
     @objc private func gifticonImageSaved(image: UIImage, error: Error?, context: UnsafeRawPointer) {
-        configureToastView()
-        showToastView()
-    }
-    
-    @objc private func dismissPopupView(_ gesture: UITapGestureRecognizer) {
-        toastView.alpha = 0
-        dimView.removeFromSuperview()
-        wrapperView.removeFromSuperview()
-    }
-    
-    private func configureToastView() {
-        dimView.backgroundColor = UIColor.black.withAlphaComponent(0.25)
-        dimView.addSubview(toastView)
-        wrapperView.addSubview(dimView)
-        
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissPopupView(_:)))
-        wrapperView.addGestureRecognizer(tapGesture)
-        wrapperView.isUserInteractionEnabled = true
-        
-        view.addSubview(wrapperView)
-        wrapperView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        
-        dimView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-        }
-        
-        toastView.snp.makeConstraints {
-            $0.width.equalTo(289)
-            $0.height.equalTo(295)
-            $0.centerX.centerY.equalToSuperview()
-        }
-
-        toastView.alpha = 0
-    }
-    
-    private func showToastView() {
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now()) {
-            UIView.transition(with: self.view, duration: 0.3, options: [.curveEaseInOut], animations: {
-                self.toastView.alpha = 1
-            }, completion: nil)
-        }
-        
-        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 4) {
-            UIView.transition(with: self.view, duration: 0.3, options: [.curveEaseInOut], animations: {
-                self.toastView.alpha = 0
-            }, completion: { _ in
-                self.dimView.removeFromSuperview()
-                self.wrapperView.removeFromSuperview()
-            })
-        }
+        let toastView = ToastView()
+        toastView.configureToastView(with: self.view, style: .save, image: .iconLogoCharacter)
+        toastView.showToastView(with: self.view)
     }
 }
 


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve https://github.com/mash-up-kr/GGiriGGiri_iOS/issues/102

# 변경사항

## 작업 내용
기존에 ResultViewController에서만 사용하던 DDipToastView를 표시하는 로직을 공통화하였습니다.


### 사용 방법
```swift
let toastView = ToastView()
toastView.configureToastView(with: self.view, style: .save, image: .iconLogoCharacter) // 파라미터로 currentView, style, image 차례대로 넣으면 됩니당
toastView.showToastView(with: self.view) // currentView
```
