### PR TITLE
[DA] 뿌리기 등록화면 작업 1️⃣ 

### DIFF
--- a/Projects/App/Sources/Common/Extension/UIPickerView+.swift
+++ b/Projects/App/Sources/Common/Extension/UIPickerView+.swift
@@ -1,0 +1,17 @@
+//
+//  UIPickerView+.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/05.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+extension UIPickerView {
+    /// UIPickerView에 노출될 Data의 타입.
+    /// - 해당 타입에 따라 적절하게 피커의 내용을 표시하는 UIPickerViewDelegate Method를 구현하면됨.
+    enum DataType {
+        case title([String])
+    }
+}

--- a/Projects/App/Sources/Common/Picker/PickerViewController.swift
+++ b/Projects/App/Sources/Common/Picker/PickerViewController.swift
@@ -1,0 +1,49 @@
+//
+//  PickerViewController.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/05.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+import DesignSystem
+
+final class PickerViewController: BaseViewController<PickerViewModelProtocol> {
+    private let dimView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .designSystem(.neutralBlack)?.withAlphaComponent(0.3)
+        return view
+    }()
+    private let pickerView = UIPickerView()
+    
+    override func configure() {
+        super.configure()
+        modalPresentationStyle = .overFullScreen
+        view.backgroundColor = .designSystem(.neutralWhite)?.withAlphaComponent(0.2)
+    }
+    
+    private func pickerViewLayout() {
+        pickerView.backgroundColor = .designSystem(.neutralWhite)
+        pickerView.delegate = viewModel
+        pickerView.dataSource = viewModel
+    }
+    
+    override func setLayout() {
+        super.setLayout()
+        view.addSubviews(with: [dimView, pickerView])
+        dimView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        pickerView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+        }
+        pickerViewLayout()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        viewModel.willDismiss()
+        dismiss(animated: false)
+    }
+}

--- a/Projects/App/Sources/Common/Picker/PickerViewModel.swift
+++ b/Projects/App/Sources/Common/Picker/PickerViewModel.swift
@@ -1,0 +1,68 @@
+//
+//  PickerViewModel.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/05.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+protocol PickerViewModelProtocol: UIPickerViewDelegate, UIPickerViewDataSource {
+    var components: Int { get set }
+    var numberOfRowsInComponent: Int { get set }
+    var dataSourceType: UIPickerView.DataType { get }
+    var didSelectItem: ((Any?) -> ()) { get }
+    
+    func willDismiss()
+}
+
+final class PickerViewModel: NSObject, PickerViewModelProtocol {
+    var components: Int = .zero
+    var numberOfRowsInComponent: Int = .zero
+    var dataSourceType: UIPickerView.DataType
+    var didSelectItem: ((Any?) -> ())
+    
+    private var currentSelectedItem: Any?
+    
+    init(dataSourceType: UIPickerView.DataType, didSelectItem: @escaping ((Any?) -> ())) {
+        self.dataSourceType = dataSourceType
+        self.didSelectItem = didSelectItem
+        
+        switch dataSourceType {
+        case let .title(titles):
+            components = 1
+            numberOfRowsInComponent = titles.count
+            currentSelectedItem = titles.first
+        }
+    }
+    
+    func willDismiss() {
+        didSelectItem(currentSelectedItem)
+    }
+}
+
+extension PickerViewModel: UIPickerViewDelegate {
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        guard case let .title(titles) = dataSourceType else { return nil }
+        return titles[row]
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        switch dataSourceType {
+        case let .title(titles):
+            didSelectItem(titles[row])
+            currentSelectedItem = titles[row]
+        }
+    }
+}
+
+extension PickerViewModel: UIPickerViewDataSource {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return components
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return numberOfRowsInComponent
+    }
+}

--- a/Projects/App/Sources/Driver/Service/GifticonAPI.swift
+++ b/Projects/App/Sources/Driver/Service/GifticonAPI.swift
@@ -9,12 +9,15 @@
 import Foundation
 
 enum GifticonAPI {
+    case categories
     case categoryList(GifticonListRequestModel)
 }
 
 extension GifticonAPI: NetworkRequestable {
     var path: String {
         switch self {
+        case .categories:
+            return "/api/v1/coupon/category"
         case .categoryList:
             return "/api/v1/sprinkles"
         }
@@ -22,6 +25,8 @@ extension GifticonAPI: NetworkRequestable {
     
     var parameters: Encodable? {
         switch self {
+        case .categories:
+            return nil
         case let .categoryList(model):
             return model
         }

--- a/Projects/App/Sources/Driver/Service/GifticonService.swift
+++ b/Projects/App/Sources/Driver/Service/GifticonService.swift
@@ -11,12 +11,17 @@ import Foundation
 import RxSwift
 
 struct GifticonService {
+    typealias CategoryListResponse = Response<[String]>
     typealias CouponListResponse = Response<[CouponEntity]>
     
     private let network: Networking
     
     init(network: Networking) {
         self.network = network
+    }
+    
+    func categories() -> CategoryListResponse {
+        network.request(GifticonAPI.categories).map()
     }
     
     func list(_ model: GifticonListRequestModel) -> CouponListResponse {

--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -104,8 +104,8 @@ extension MainViewModel: PHPickerViewControllerDelegate {
                     }
                     
                     self.alert?(nil, "쿠폰 이미지 분석 중~", nil, nil, { _ in
-                        let registerGifticonViewController = RegisterGifticonViewController()
-                        registerGifticonViewController.giftionImage = image
+                        let viewModel = RegisterGifticonViewModel(network: Network(), gifticonImage: image)
+                        let registerGifticonViewController = RegisterGifticonViewController(viewModel)
                         registerGifticonViewController.modalPresentationStyle = .fullScreen
                         self.present?(registerGifticonViewController)
                     })

--- a/Projects/App/Sources/Main/View/CategoryCollectionViewCell.swift
+++ b/Projects/App/Sources/Main/View/CategoryCollectionViewCell.swift
@@ -23,19 +23,6 @@ final class CategoryCollectionViewCell: UICollectionViewCell {
     
     private let categoryButton = DDIPCategoryButton()
     
-    func configure(_ category: [Category], with index: Int) {
-        nameLabel.textAlignment = .center
-        nameLabel.clipsToBounds = true
-        
-        categoryType = Category.allCases[index]
-        
-        if category == Category.register {
-            nameLabel.text = Category.register[index].rawValue
-            return
-        }
-        nameLabel.text = Category.allCases[index].rawValue
-    }
-    
     override init(frame: CGRect) {
         super.init(frame: frame)
         
@@ -58,5 +45,29 @@ final class CategoryCollectionViewCell: UICollectionViewCell {
     
     private func configure() {
         categoryButton.isUserInteractionEnabled = false
+        categoryButton.setHeight(.height_34)
+        self.layer.cornerRadius = 17
+        self.clipsToBounds = true
+    }
+    
+    func updateButton(isSelected: Bool) {
+        categoryButton.isSelected = isSelected
+    }
+    
+    func update(_ category: String) {
+        categoryButton.setButtonTitle(category)
+    }
+    
+    func configure(_ category: [Category], with index: Int) {
+        nameLabel.textAlignment = .center
+        nameLabel.clipsToBounds = true
+        
+        categoryType = Category.allCases[index]
+        
+        if category == Category.register {
+            nameLabel.text = Category.register[index].rawValue
+            return
+        }
+        nameLabel.text = Category.allCases[index].rawValue
     }
 }

--- a/Projects/App/Sources/Register/CategoryCollectionViewDataSource.swift
+++ b/Projects/App/Sources/Register/CategoryCollectionViewDataSource.swift
@@ -8,16 +8,21 @@
 
 import UIKit
 
-final class CategoryCollectionViewDataSource: NSObject, UICollectionViewDataSource {
+final class CategoryCollectionViewDataSource: NSObject {
+    private var category: [String] = []
     
-    private let category = Category.allCases.filter { return $0 != Category.all }
-    
+    func update(_ category: [String]) {
+        self.category = category
+    }
+}
+
+extension CategoryCollectionViewDataSource: UICollectionViewDataSource {
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 1
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return Category.register.count
+        return category.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -25,7 +30,7 @@ final class CategoryCollectionViewDataSource: NSObject, UICollectionViewDataSour
                                                           for: indexPath) else {
             return UICollectionViewCell()
         }
-        cell.configure(Category.register, with: indexPath.item)
+        cell.update(category[indexPath.row])
         return cell
     }
 }

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -19,44 +19,73 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
             title: "기프티콘 등록",
             rightButtonsItem: nil)
     }()
+    private let scrollView = UIScrollView()
+    private let contentView = UIView()
     
+    private let registerGifticonView = RegisterGifticonView()
     public var giftionImage = UIImage()
+    private let registerButton = DDIPCTAButton()
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
+    private let disposeBag = DisposeBag()
+    
+    override func configure() {
+        super.configure()
         view.backgroundColor = .designSystem(.neutralWhite)
         
         configureNavigationBar()
-        configure()
-    }
-    
-    private func configure() {
-        view.addSubview(registerGifticonView)
-        
-        registerGifticonView.snp.makeConstraints {
-            $0.top.equalTo(navigationBar.snp.bottom)
-            $0.leading.trailing.bottom.equalToSuperview()
-        }
         
         registerGifticonView.registerGiftionImageView.imageView.image = giftionImage
         registerGifticonView.registerGiftionImageView.delegate = self
+        
+        registerButton.setTitle(title: "내용을 입력해야 뿌릴 수 있어요")
+        registerButton.setBackgroundColor(buttonColor: .secondarySkyblue200)
     }
     
     private func configureNavigationBar() {
-        view.addSubview(navigationBar)
+        navigationBar.leftButtonTapEvent
+            .subscribe(onNext: { [weak self] in
+                self?.dismiss(animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    override func setLayout() {
+        super.setLayout()
+        view.addSubviews(with: [navigationBar, scrollView, registerGifticonView, registerButton])
         
         navigationBar.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview()
         }
+        scrollView.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.leading.trailing.equalToSuperview()
+        }
+        registerButton.snp.makeConstraints {
+            $0.top.equalTo(scrollView.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
         
-        navigationBar.leftButtonTapEvent.subscribe(onNext: { [weak self] in
-            self?.dismiss(animated: true)
-        }).disposed(by: disposeBag)
+        setContentViewLayout()
     }
 }
 
+// MARK: - Layout
+
+extension RegisterGifticonViewController {
+    private func setContentViewLayout() {
+        scrollView.addSubview(contentView)
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalTo(view)
+        }
+        contentView.addSubview(registerGifticonView)
+        registerGifticonView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+}
 
 extension RegisterGifticonViewController: RegisterGifticonImageViewButtonDelegate {
     func originalButtonTapped() {

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -158,7 +158,7 @@ extension RegisterGifticonViewController {
         registerButton.snp.updateConstraints {
             $0.top.equalTo(scrollView.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(insetValue + 34)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(insetValue)
         }
         
         UIView.animate(withDuration: keyboardAnimationDuration.doubleValue) { [weak self] in

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -23,7 +23,6 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
     private let contentView = UIView()
     
     private let registerGifticonView = RegisterGifticonView()
-    public var giftionImage = UIImage()
     private let registerButton = DDIPCTAButton()
     
     private let disposeBag = DisposeBag()
@@ -35,36 +34,11 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
         
         configureNavigationBar()
         
-        registerGifticonView.registerGiftionImageView.imageView.image = giftionImage
-        registerGifticonView.registerGiftionImageView.delegate = self
-        registerGifticonView.showTimeSelectPicker = { [weak self] in
-            self?.showPicker()
-        }
+        configureGifiticonInfoView()
         
-        registerButton.setTitle(title: "내용을 입력해야 뿌릴 수 있어요")
-        registerButton.setBackgroundColor(buttonColor: .secondarySkyblue200)
+        configureKeyboardOberver()
         
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(willShowKeyboard),
-            name: UIWindow.keyboardWillShowNotification,
-            object: nil
-        )
-        
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(willHideKeyboard),
-            name: UIWindow.keyboardWillHideNotification,
-            object: nil
-        )
-    }
-    
-    private func configureNavigationBar() {
-        navigationBar.leftButtonTapEvent
-            .subscribe(onNext: { [weak self] in
-                self?.dismiss(animated: true)
-            })
-            .disposed(by: disposeBag)
+        configureRegisterButton()
     }
     
     override func setLayout() {
@@ -86,6 +60,47 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
         }
         
         setContentViewLayout()
+    }
+}
+
+// MARK: - Configure
+
+extension RegisterGifticonViewController {
+    private func configureNavigationBar() {
+        navigationBar.leftButtonTapEvent
+            .subscribe(onNext: { [weak self] in
+                self?.dismiss(animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func configureKeyboardOberver() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(willShowKeyboard),
+            name: UIWindow.keyboardWillShowNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(willHideKeyboard),
+            name: UIWindow.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+    
+    private func configureGifiticonInfoView() {
+        registerGifticonView.registerGiftionImageView.imageView.image = viewModel.gifticonImage
+        registerGifticonView.registerGiftionImageView.delegate = self
+        registerGifticonView.showTimeSelectPicker = { [weak self] in
+            self?.showPicker()
+        }
+    }
+    
+    private func configureRegisterButton() {
+        registerButton.setTitle(title: "내용을 입력해야 뿌릴 수 있어요")
+        registerButton.setBackgroundColor(buttonColor: .secondarySkyblue200)
     }
 }
 
@@ -167,7 +182,7 @@ extension RegisterGifticonViewController {
 extension RegisterGifticonViewController: RegisterGifticonImageViewButtonDelegate {
     func originalButtonTapped() {
         let gifticonImageViewController = GiftionImageViewController()
-        gifticonImageViewController.giftionImageView.image = giftionImage
+        gifticonImageViewController.giftionImageView.image = viewModel.gifticonImage
         present(gifticonImageViewController, animated: true)
     }
 }

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -12,11 +12,7 @@ import DesignSystem
 import RxSwift
 import SnapKit
 
-final class RegisterGifticonViewController: UIViewController {
-
-    private let disposeBag = DisposeBag()
-    
-    private let registerGifticonView = RegisterGifticonView()
+final class RegisterGifticonViewController: BaseViewController<RegisterGifticonViewModelProtocol> {
     private lazy var navigationBar: DDIPNavigationBar = {
         return DDIPNavigationBar(
             leftBarItem: DDIPNavigationBar.BarItem.cancel,

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -37,6 +37,9 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
         
         registerGifticonView.registerGiftionImageView.imageView.image = giftionImage
         registerGifticonView.registerGiftionImageView.delegate = self
+        registerGifticonView.showTimeSelectPicker = { [weak self] in
+            self?.showPicker()
+        }
         
         registerButton.setTitle(title: "내용을 입력해야 뿌릴 수 있어요")
         registerButton.setBackgroundColor(buttonColor: .secondarySkyblue200)
@@ -143,6 +146,21 @@ extension RegisterGifticonViewController {
 extension RegisterGifticonViewController: UIScrollViewDelegate {
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         view.endEditing(true)
+    }
+}
+
+// MARK: - Picker
+
+extension RegisterGifticonViewController {
+    func showPicker() {
+        let pickerViewController = PickerViewController(PickerViewModel(dataSourceType: .title(
+            // TODO: - 임의로 넣은 피커 데이터. 확인 필요
+            ["30분", "1시간", "1시간30분", "2시간", "2시간 30분"]
+        ), didSelectItem: { [weak self] time in
+            guard let time = time as? String else { return }
+            self?.registerGifticonView.updateTime(time)
+        }))
+        present(pickerViewController, animated: false)
     }
 }
 

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -61,6 +61,17 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
         
         setContentViewLayout()
     }
+    
+    override func bind() {
+        super.bind()
+        
+        viewModel.categories
+            .skip(1)
+            .subscribe(onNext: { [weak self] in
+                self?.registerGifticonView.updateCategories($0)
+            })
+            .disposed(by: disposeBag)
+    }
 }
 
 // MARK: - Configure
@@ -91,8 +102,8 @@ extension RegisterGifticonViewController {
     }
     
     private func configureGifiticonInfoView() {
-        registerGifticonView.registerGiftionImageView.imageView.image = viewModel.gifticonImage
-        registerGifticonView.registerGiftionImageView.delegate = self
+        registerGifticonView.updateGifticonImage(viewModel.gifticonImage)
+        registerGifticonView.originalImageDelegate(self)
         registerGifticonView.showTimeSelectPicker = { [weak self] in
             self?.showPicker()
         }

--- a/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
@@ -8,14 +8,35 @@
 
 import UIKit
 
+import RxRelay
+import RxSwift
+
 protocol RegisterGifticonViewModelProtocol {
     var gifticonImage: UIImage { get set }
+    var categories: BehaviorRelay<[String]> { get }
 }
 
 final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
-    var gifticonImage: UIImage
+    private let network: Networking
+    private lazy var service = GifticonService(network: network)
+    private let disposeBag = DisposeBag()
     
-    init(gifticonImage: UIImage) {
+    var gifticonImage: UIImage
+    var categories = BehaviorRelay<[String]>(value: [])
+    
+    init(network: Networking, gifticonImage: UIImage) {
+        self.network = network
         self.gifticonImage = gifticonImage
+        
+        fetchCategories()
+    }
+    
+    func fetchCategories() {
+        service.categories()
+            .subscribe(onSuccess: { [weak self] in
+                guard let cateogires = $0.data else { return }
+                self?.categories.accept(cateogires)
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
@@ -9,9 +9,13 @@
 import UIKit
 
 protocol RegisterGifticonViewModelProtocol {
-    
+    var gifticonImage: UIImage { get set }
 }
 
 final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
+    var gifticonImage: UIImage
     
+    init(gifticonImage: UIImage) {
+        self.gifticonImage = gifticonImage
+    }
 }

--- a/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
@@ -1,0 +1,17 @@
+//
+//  RegisterGifticonViewModel.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/05.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+protocol RegisterGifticonViewModelProtocol {
+    
+}
+
+final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
+    
+}

--- a/Projects/App/Sources/Register/View/RegisterGifticonDDipInfoView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonDDipInfoView.swift
@@ -26,7 +26,7 @@ final class RegisterGifticonDDipInfoView: BaseView {
             self?.didTapTimeSelect?()
         }),
         title: "마감시간",
-        placeholder: "1시간"
+        placeholder: "마감시간을 선택해주세요"
     )
     
     var didTapTimeSelect: (() -> ())?

--- a/Projects/App/Sources/Register/View/RegisterGifticonDDipInfoView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonDDipInfoView.swift
@@ -21,9 +21,15 @@ final class RegisterGifticonDDipInfoView: BaseView {
         return label
     }()
     
-    private lazy var timeInputView = DDIPInputView(inputType: .custom(action: { [weak self] in
-        self?.showTimeSelectPicker()
-    }), title: "마감시간", placeholder: "1시간")
+    private lazy var timeInputView = DDIPInputView(
+        inputType: .custom(action: { [weak self] in
+            self?.didTapTimeSelect?()
+        }),
+        title: "마감시간",
+        placeholder: "1시간"
+    )
+    
+    var didTapTimeSelect: (() -> ())?
     
     override func setLayout() {
         super.setLayout()
@@ -41,8 +47,10 @@ final class RegisterGifticonDDipInfoView: BaseView {
             $0.bottom.equalToSuperview()
         }
     }
-    
-    private func showTimeSelectPicker() {
-        // TODO: 로직 작성하기
+}
+
+extension RegisterGifticonDDipInfoView {
+    func update(time: String) {
+        timeInputView.update(text: time)
     }
 }

--- a/Projects/App/Sources/Register/View/RegisterGifticonInfoView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonInfoView.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 import DesignSystem
+import RxSwift
 import SnapKit
 
 /// 기프티콘 정보 - 기프티콘 정보 뷰
@@ -31,7 +32,6 @@ final class RegisterGifticonInfoView: BaseView {
     
     private lazy var categoryView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: generateLayout())
-        collectionView.backgroundColor = .yellow
         collectionView.register(CategoryCollectionViewCell.self)
         return collectionView
     }()
@@ -41,29 +41,44 @@ final class RegisterGifticonInfoView: BaseView {
     private let expirationDateInputView = DDIPInputView(inputType: .text,
                                                              title: "유효기간",
                                                              placeholder: "유효기간(YYYY.MM.DD)을 입력해주세요")
+    
+    private let disposeBag = DisposeBag()
+    
     private func generateLayout() -> UICollectionViewLayout {
-        let layout =
-        UICollectionViewCompositionalLayout { (sectionIndex: Int, _) -> NSCollectionLayoutSection? in
+        let layout = UICollectionViewCompositionalLayout { (_, _) in
             return self.generateCategorySection()
         }
         return layout
     }
     
     private func generateCategorySection() -> NSCollectionLayoutSection {
-        let item = CollectionViewLayoutManager.configureItem(with:
-                                                                CollectionViewConfigureSize(
-                                                                    widthDimension: .estimated(1),
-                                                                    heightDimension: .estimated(1)))
+        let item = CollectionViewLayoutManager.configureItem(
+            with: CollectionViewConfigureSize(
+                widthDimension: .estimated(10),
+                heightDimension: .absolute(34)
+            )
+        )
         
-        let group = CollectionViewLayoutManager.configureGroup(with:
-                                                                CollectionViewConfigureSize(
-                                                                    widthDimension: .fractionalWidth(1),
-                                                                    heightDimension: .estimated(1)),
-                                                               item: item)
+        let group = CollectionViewLayoutManager.configureGroup(
+            with: CollectionViewConfigureSize(
+                widthDimension: .fractionalWidth(1),
+                heightDimension: .absolute(34)
+            ),
+            edgeSpacing: .init(
+                leading: .none,
+                top: .none,
+                trailing: .fixed(10),
+                bottom: .fixed(10)
+            ),
+            item: item
+        )
         
-        let section = CollectionViewLayoutManager.configureSection(with: group,
-                                                                   scrollingBehavior: nil,
-                                                                   header: nil)
+        let section = CollectionViewLayoutManager.configureSection(
+            with: group,
+            scrollingBehavior: nil,
+            header: nil
+        )
+        
         return section
     }
     
@@ -120,6 +135,15 @@ final class RegisterGifticonInfoView: BaseView {
     override func configure() {
         super.configure()
         categoryView.dataSource = categoryCollectionViewDataSource
+        categoryView.delegate = self
+        categoryView.rx.observe(CGSize.self, "contentSize")
+            .distinctUntilChanged()
+            .subscribe(onNext: { [weak self] in
+                guard let size = $0, size.height != .zero else { return }
+                self?.updateCategoryViewHeight(size.height)
+            })
+            .disposed(by: disposeBag)
+        
         expirationDateInputView.update(keyboardType: .numberPad)
         expirationDateInputView.update { [weak self] text in
             let count = text?.count ?? .zero
@@ -130,5 +154,29 @@ final class RegisterGifticonInfoView: BaseView {
             }
             return true
         }
+    }
+    
+    private func updateCategoryViewHeight(_ height: CGFloat) {
+        categoryView.snp.updateConstraints {
+            $0.height.equalTo(height)
+        }
+    }
+    
+    func updateCategoryDataSource(_ data: [String]) {
+        categoryCollectionViewDataSource.update(data)
+        categoryView.reloadData()
+    }
+}
+
+// TODO: datasource와 같은수준으로 빼기
+extension RegisterGifticonInfoView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? CategoryCollectionViewCell else { return }
+        cell.updateButton(isSelected: true)
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? CategoryCollectionViewCell else { return }
+        cell.updateButton(isSelected: false)
     }
 }

--- a/Projects/App/Sources/Register/View/RegisterGifticonInfoView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonInfoView.swift
@@ -36,8 +36,8 @@ final class RegisterGifticonInfoView: BaseView {
         return collectionView
     }()
     
-    private let barndInputView = DDIPInputView(title: "브랜드", placeholder: "브랜드명을 입력해주세요.")
-    private let nameInputView = DDIPInputView(title: "제품명", placeholder: "제품명을 입력해주세요.")
+    private let barndInputView = DDIPInputView(title: "브랜드", placeholder: "브랜드명을 입력해주세요")
+    private let nameInputView = DDIPInputView(title: "제품명", placeholder: "제품명을 입력해주세요")
     private let expirationDateInputView = DDIPInputView(inputType: .text,
                                                              title: "유효기간",
                                                              placeholder: "유효기간(YYYY.MM.DD)을 입력해주세요")

--- a/Projects/App/Sources/Register/View/RegisterGifticonView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonView.swift
@@ -118,7 +118,7 @@ fileprivate class InfoMessageView: BaseView {
         super.configure()
         
         self.layer.cornerRadius = 8
-        backgroundColor = .yellow
+        backgroundColor = .designSystem(.secondaryYellow)
     }
 }
 

--- a/Projects/App/Sources/Register/View/RegisterGifticonView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonView.swift
@@ -13,42 +13,18 @@ import SnapKit
 
 /// 기프티콘 정보 등록 화면
 final class RegisterGifticonView: BaseView {
-    private let scrollView = UIScrollView()
-    private let contentView = UIView()
     private(set) var registerGiftionImageView = RegisterGiftionImageView()
     private let infoMessageView = InfoMessageView()
     private let registerGifticonInfoView = RegisterGifticonInfoView()
     private let registerGifticonDDipInfoView = RegisterGifticonDDipInfoView()
-    private let registerButton = DDIPCTAButton()
     
     override func setLayout() {
         super.setLayout()
+        addSubviews(with: [registerGiftionImageView,
+                           infoMessageView,
+                           registerGifticonInfoView,
+                           registerGifticonDDipInfoView])
         
-        addSubviews(with: [scrollView, registerButton])
-        
-        scrollView.snp.makeConstraints {
-            $0.top.leading.trailing.equalToSuperview()
-        }
-        registerButton.snp.makeConstraints {
-            $0.top.equalTo(scrollView.snp.bottom).offset(16)
-            $0.leading.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalTo(safeAreaLayoutGuide)
-        }
-        
-        contentViewLayout()
-    }
-    
-    private func contentViewLayout() {
-        scrollView.addSubview(contentView)
-        contentView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-            $0.width.equalTo(UIScreen.main.bounds.width)
-        }
-        
-        contentView.addSubviews(with: [registerGiftionImageView,
-                                      infoMessageView,
-                                      registerGifticonInfoView,
-                                      registerGifticonDDipInfoView])
         
         registerGiftionImageView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(6)

--- a/Projects/App/Sources/Register/View/RegisterGifticonView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonView.swift
@@ -18,6 +18,8 @@ final class RegisterGifticonView: BaseView {
     private let registerGifticonInfoView = RegisterGifticonInfoView()
     private let registerGifticonDDipInfoView = RegisterGifticonDDipInfoView()
     
+    var showTimeSelectPicker: (() -> ())?
+    
     override func setLayout() {
         super.setLayout()
         addSubviews(with: [registerGiftionImageView,
@@ -51,6 +53,16 @@ final class RegisterGifticonView: BaseView {
     
     override func configure() {
         super.configure()
+        
+        registerGifticonDDipInfoView.didTapTimeSelect = { [weak self] in
+            self?.showTimeSelectPicker?()
+        }
+    }
+}
+
+extension RegisterGifticonView {
+    func updateTime(_ time: String) {
+        registerGifticonDDipInfoView.update(time: time)
     }
 }
 

--- a/Projects/App/Sources/Register/View/RegisterGifticonView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonView.swift
@@ -13,39 +13,39 @@ import SnapKit
 
 /// 기프티콘 정보 등록 화면
 final class RegisterGifticonView: BaseView {
-    private(set) var registerGiftionImageView = RegisterGiftionImageView()
+    private let gifticonImageView = RegisterGiftionImageView()
     private let infoMessageView = InfoMessageView()
-    private let registerGifticonInfoView = RegisterGifticonInfoView()
-    private let registerGifticonDDipInfoView = RegisterGifticonDDipInfoView()
+    private let gifticonInfoView = RegisterGifticonInfoView()
+    private let ddipInfoView = RegisterGifticonDDipInfoView()
     
     var showTimeSelectPicker: (() -> ())?
     
     override func setLayout() {
         super.setLayout()
-        addSubviews(with: [registerGiftionImageView,
+        addSubviews(with: [gifticonImageView,
                            infoMessageView,
-                           registerGifticonInfoView,
-                           registerGifticonDDipInfoView])
+                           gifticonInfoView,
+                           ddipInfoView])
         
         
-        registerGiftionImageView.snp.makeConstraints {
+        gifticonImageView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(6)
             $0.leading.trailing.equalToSuperview().inset(16)
             $0.height.equalTo(294)
         }
         
         infoMessageView.snp.makeConstraints {
-            $0.top.equalTo(registerGiftionImageView.snp.bottom).offset(16)
+            $0.top.equalTo(gifticonImageView.snp.bottom).offset(16)
             $0.leading.trailing.equalToSuperview().inset(16)
         }
         
-        registerGifticonInfoView.snp.makeConstraints {
+        gifticonInfoView.snp.makeConstraints {
             $0.top.equalTo(infoMessageView.snp.bottom).offset(40)
             $0.leading.trailing.equalTo(infoMessageView)
         }
         
-        registerGifticonDDipInfoView.snp.makeConstraints {
-            $0.top.equalTo(registerGifticonInfoView.snp.bottom).offset(48)
+        ddipInfoView.snp.makeConstraints {
+            $0.top.equalTo(gifticonInfoView.snp.bottom).offset(48)
             $0.leading.trailing.equalTo(infoMessageView)
             $0.bottom.equalToSuperview()
         }
@@ -54,7 +54,7 @@ final class RegisterGifticonView: BaseView {
     override func configure() {
         super.configure()
         
-        registerGifticonDDipInfoView.didTapTimeSelect = { [weak self] in
+        ddipInfoView.didTapTimeSelect = { [weak self] in
             self?.showTimeSelectPicker?()
         }
     }
@@ -62,7 +62,19 @@ final class RegisterGifticonView: BaseView {
 
 extension RegisterGifticonView {
     func updateTime(_ time: String) {
-        registerGifticonDDipInfoView.update(time: time)
+        ddipInfoView.update(time: time)
+    }
+    
+    func updateCategories(_ categories: [String]) {
+        gifticonInfoView.updateCategoryDataSource(categories)
+    }
+    
+    func updateGifticonImage(_ image: UIImage) {
+        gifticonImageView.imageView.image = image
+    }
+    
+    func originalImageDelegate(_ delegate: RegisterGifticonImageViewButtonDelegate) {
+        gifticonImageView.delegate = delegate
     }
 }
 

--- a/Projects/App/Sources/Usecase/GifticonEntity.swift
+++ b/Projects/App/Sources/Usecase/GifticonEntity.swift
@@ -1,0 +1,13 @@
+//
+//  GifticonEntity.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/07.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import Foundation
+
+struct GifticonEntity {
+    
+}

--- a/Projects/DesignSystem/Resources/Color.xcassets/SecondaryYellow.colorset/Contents.json
+++ b/Projects/DesignSystem/Resources/Color.xcassets/SecondaryYellow.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.855",
+          "green" : "0.969",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/DesignSystem/Sources/Color/Color.swift
+++ b/Projects/DesignSystem/Sources/Color/Color.swift
@@ -20,6 +20,8 @@ public enum DDIPColor {
     case secondaryBlue
     case secondarySkyblue200
     case secondarySkyblue100
+    case secondaryYellow
+    
     case dangerRaspberry
     
     /// 컬러를 불러오기 위한 name space
@@ -36,6 +38,7 @@ public enum DDIPColor {
         case .secondaryBlue: return "SecondaryBlue"
         case .secondarySkyblue200: return "SecondarySkyblue200"
         case .secondarySkyblue100: return "SecondarySkyblue100"
+        case .secondaryYellow: return "SecondaryYellow"
         case .dangerRaspberry: return "DangerRaspberry"
         }
     }

--- a/Projects/DesignSystem/Sources/Component/Button/DDIPCategoryButton.swift
+++ b/Projects/DesignSystem/Sources/Component/Button/DDIPCategoryButton.swift
@@ -13,6 +13,13 @@ public class DDIPCategoryButton: UIButton {
         case height_34 = 34
         case height_36 = 36
     }
+    
+    public override var isSelected: Bool {
+        didSet {
+            updateFont()
+            updateBorder()
+        }
+    }
 
     public init() {
         super.init(frame: .zero)
@@ -24,8 +31,6 @@ public class DDIPCategoryButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
 
-
-
     private func setButton() {
         self.translatesAutoresizingMaskIntoConstraints = false
     }
@@ -33,8 +38,29 @@ public class DDIPCategoryButton: UIButton {
     private func setAttribute() {
         self.layer.cornerRadius = 17
 
-        self.setTitleColor(.designSystem(.neutralWhite), for: .normal)
-        self.titleLabel?.font = .designSystem(.pretendard, family: .bold, size: ._14)
+        self.setTitleColor(.designSystem(.neutralBlack), for: .normal)
+        self.setTitleColor(.designSystem(.neutralWhite), for: .selected)
+        
+        self.setBackgroundColor(.designSystem(.neutralWhite), for: .normal)
+        self.setBackgroundColor(.designSystem(.secondaryBlue), for: .selected)
+        
+        setEdgeInset(topInset: 7, leftInset: 20, rightInset: 20, bottomInset: 7)
+        
+        updateFont()
+        updateBorder()
+    }
+    
+    private func updateFont() {
+        self.titleLabel?.font = isSelected ?
+            .designSystem(.pretendard, family: .bold, size: ._14) :
+            .designSystem(.pretendard, family: .medium, size: ._14)
+    }
+    
+    private func updateBorder() {
+        self.layer.borderWidth = isSelected ? .zero : 0.5
+        self.layer.borderColor = isSelected ?
+            UIColor.clear.cgColor :
+            UIColor.designSystem(.neutralGray300)?.cgColor
     }
 }
 
@@ -53,6 +79,8 @@ extension DDIPCategoryButton {
         NSLayoutConstraint.activate([
             self.heightAnchor.constraint(equalToConstant: height.rawValue),
         ])
+        
+        self.layer.cornerRadius = height == .height_34 ? 17 : 18
     }
 
     public func setEdgeInset(

--- a/Projects/DesignSystem/Sources/Component/Extension/UIButton+.swift
+++ b/Projects/DesignSystem/Sources/Component/Extension/UIButton+.swift
@@ -1,0 +1,25 @@
+//
+//  UIButton+.swift
+//  DesignSystem
+//
+//  Created by AhnSangHoon on 2022/08/07.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+extension UIButton {
+    func setBackgroundColor(_ color: UIColor?, for state: UIControl.State) {
+        
+        UIGraphicsBeginImageContext(CGSize(width: 1.0, height: 1.0))
+        guard let context = UIGraphicsGetCurrentContext(), let color = color else { return }
+
+        context.setFillColor(color.cgColor)
+        context.fill(CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0))
+        
+        let backgroundImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+         
+        self.setBackgroundImage(backgroundImage, for: state)
+    }
+}

--- a/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
+++ b/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
@@ -74,6 +74,7 @@ public final class DDIPInputField: UIView {
     
     public init(placeholder: String? = nil, condition: ((String?) -> (Bool))? = nil) {
         super.init(frame: .zero)
+        configure()
         layout()
         bind()
         
@@ -83,6 +84,14 @@ public final class DDIPInputField: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Configure
+
+extension DDIPInputField {
+    private func configure() {
+        textfield.delegate = self
     }
 }
 
@@ -144,6 +153,13 @@ extension DDIPInputField {
             return .normal
         } 
         return .error
+    }
+}
+
+extension DDIPInputField: UITextFieldDelegate {
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        endEditing(true)
+        return true
     }
 }
 


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : #100 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* 538b6d334ff4df25380d04f4f3133f354dae14a2 커밋에서 피커를 공통으로 사용할 수 있도록 컴포넌트를 만들었습니다.
    * 피커에 필요한 DataType enum case를 추가하고, associated value를 통해 실제 데이터를 전달하는 방식입니다.
    * 이 때, 현재는 title을 통한 Picker 노출만 되어있기 때문에 customView를 통해 피커를 표시한다면 UIPickerDelegate Method를 구현하여야 합니다.
* 538b6d334ff4df25380d04f4f3133f354dae14a2, 6a3cbe77fc16a28fa638677134901da92db9b289 두 커밋에서 키보드 노출로 인해 input filed 가 가려지는 현상을 대응하였고, 유저가 편리하게 키보드를 닫을 수 있도록 두가지 방법을 추가했습니다.
    * 키보드의 return을 눌러 키보드를 닫기
    * 화면 스크롤 시 키보드 닫기
* 71083cbe2b5e73d40b3ef175465d8ac0954b868e 커밋에서 DDIPCategoryButton을 수정하였습니다. (cc. @kimkyunghun3)
    * 버튼의 `isSelected` 변경에 따라 `backgroundColor`, `font`, `border`가 변경되도록 수정하였습니다.
    * `height` 설정에 따라 `cornerRadius`가 변경되도록 수정하였습니다.
* e4cc4a1c2dc6e0270de678294763b00eab837d82 등록화면에서 필요한 카테고리 목록을 불러오는 API를 임시로 적용하였습니다.
    * 앱에서 공통으로 사용되는 해당 API 및 Response에 대한 내용은 팀 내부의 sync를 맞춰 어떻게 사용해야할 지 논의가 필요할 것 같습니다. (cc. @ios-h , @kimkyunghun3)
* fa1617d6bcdb97944ac1dc2bdfbe3c9f9f3da025 등록화면에서 사용되는 designSystemColor를 추가하였습니다.

### 미리보기
<!-- 작업 전/후 스크린샷으로 표현하기 어려울 경우 영상을 첨부합니다. -->

작업 후

https://user-images.githubusercontent.com/39300449/183338310-216e946b-fad5-4250-8451-a6d5e1999b96.mp4


