### PR TITLE
[DA] 뿌리기 등록화면 작업 2️⃣ 

### DIFF
--- a/Projects/App/Sources/Driver/Extension/Encodable+Alamofire.swift
+++ b/Projects/App/Sources/Driver/Extension/Encodable+Alamofire.swift
@@ -1,0 +1,25 @@
+//
+//  Encodable+Alamofire.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/09.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+extension Encodable {
+    var requestable: Parameters {
+        do {
+            let data = try JSONEncoder().encode(self)
+            guard let dictionary = try JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? [String: Any] else {
+                return [:]
+            }
+            return dictionary
+        } catch {
+            return [:]
+        }
+    }
+}

--- a/Projects/App/Sources/Driver/Extension/HttpHeaders+UIKit.swift
+++ b/Projects/App/Sources/Driver/Extension/HttpHeaders+UIKit.swift
@@ -1,0 +1,25 @@
+//
+//  HttpHeaders+.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/09.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+import Alamofire
+
+extension HTTPHeaders {
+    static var `default`: HTTPHeaders {
+        HTTPHeaders([
+            "Authorization" : UIDevice.current.identifierForVendor?.description ?? .init().description
+        ])
+    }
+    
+    static var multipartHeader: HTTPHeaders {
+        var headers = HTTPHeaders.default
+        headers.update(.contentType("multipart/form-data"))
+        return headers
+    }
+}

--- a/Projects/App/Sources/Driver/Networking/NetworkRequestable.swift
+++ b/Projects/App/Sources/Driver/Networking/NetworkRequestable.swift
@@ -57,10 +57,6 @@ extension NetworkRequestable {
     }
     
     var headers: HTTPHeaders {
-        HTTPHeaders([
-            "Authorization" : UIDevice.current.identifierForVendor?.description ?? .init().description
-        ])
+        .default
     }
 }
-
-

--- a/Projects/App/Sources/Driver/Networking/RequestModel/SprinkleRegisterRequestModel.swift
+++ b/Projects/App/Sources/Driver/Networking/RequestModel/SprinkleRegisterRequestModel.swift
@@ -1,0 +1,35 @@
+//
+//  SprinkleRegisterRequestModel.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/09.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import Foundation
+
+struct SprinkleRegisterRequestModel: Encodable {
+    struct Information: Encodable {
+        let category: String
+        let brandName: String
+        let merchandiseName: String
+        let couponExpiredTime: String
+        let deadlineMinutes: Int
+        
+        init(_ entity: SprinkleInformation) {
+            self.category = entity.category ?? ""
+            self.brandName = entity.brandName ?? ""
+            self.merchandiseName = entity.productName ?? ""
+            self.couponExpiredTime = entity.expirationDate ?? ""
+            self.deadlineMinutes = entity.intDeadLineMinute()
+        }
+    }
+    
+    let image: Data
+    let eventInfo: Information
+    
+    init(_ entity: SprinkleInformation) {
+        self.image = entity.image.pngData() ?? Data()
+        eventInfo = Information(entity)
+    }
+}

--- a/Projects/App/Sources/Driver/Networking/ResponseModel/BaseResponseModel.swift
+++ b/Projects/App/Sources/Driver/Networking/ResponseModel/BaseResponseModel.swift
@@ -8,9 +8,16 @@
 
 import RxSwift
 
-typealias Response<T: Decodable> = Single<BaseResponseModel<T>>
+typealias Response = Single<BaseResponseModel>
 
-struct BaseResponseModel<T: Decodable>: Decodable {
+struct BaseResponseModel: Decodable {
+    let code: String
+    let message: String
+}
+
+typealias ResponseData<T: Decodable> = Single<BaseDataResponseModel<T>>
+
+struct BaseDataResponseModel<T: Decodable>: Decodable {
     let code: String
     let message: String
     let data: T?

--- a/Projects/App/Sources/Driver/Service/GifticonAPI.swift
+++ b/Projects/App/Sources/Driver/Service/GifticonAPI.swift
@@ -8,9 +8,12 @@
 
 import Foundation
 
+import Alamofire
+
 enum GifticonAPI {
     case categories
     case categoryList(GifticonListRequestModel)
+    case registerSprinkle(SprinkleRegisterRequestModel)
 }
 
 extension GifticonAPI: NetworkRequestable {
@@ -20,6 +23,17 @@ extension GifticonAPI: NetworkRequestable {
             return "/api/v1/coupon/category"
         case .categoryList:
             return "/api/v1/sprinkles"
+        case .registerSprinkle:
+            return "/api/v1/sprinkle"
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .categories, .categoryList:
+            return .get
+        case .registerSprinkle:
+            return .post
         }
     }
     
@@ -29,6 +43,17 @@ extension GifticonAPI: NetworkRequestable {
             return nil
         case let .categoryList(model):
             return model
+        case let .registerSprinkle(model):
+            return model
+        }
+    }
+    
+    var headers: HTTPHeaders {
+        switch self {
+        case .categories, .categoryList:
+            return .default
+        case .registerSprinkle:
+            return .multipartHeader
         }
     }
 }

--- a/Projects/App/Sources/Driver/Service/GifticonService.swift
+++ b/Projects/App/Sources/Driver/Service/GifticonService.swift
@@ -11,8 +11,9 @@ import Foundation
 import RxSwift
 
 struct GifticonService {
-    typealias CategoryListResponse = Response<[String]>
-    typealias CouponListResponse = Response<[CouponEntity]>
+    typealias CategoryListResponse = ResponseData<[String]>
+    typealias CouponListResponse = ResponseData<[CouponEntity]>
+    typealias RegisterSprinkleResponse = Response
     
     private let network: Networking
     
@@ -26,5 +27,13 @@ struct GifticonService {
     
     func list(_ model: GifticonListRequestModel) -> CouponListResponse {
         network.request(GifticonAPI.categoryList(model)).map()
+    }
+    
+    func registerSprinkle(_ entity: SprinkleInformation) -> RegisterSprinkleResponse {
+        network.request(
+            GifticonAPI.registerSprinkle(
+                SprinkleRegisterRequestModel(entity)
+            )
+        ).map()
     }
 }

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -97,6 +97,15 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
         registerGifticonView.updateDeadLineMinute = { [weak self] in
             self?.viewModel.update(.deadLineMinute($0))
         }
+        
+        registerButton.rx.tap
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] _ in
+                // TODO: - 인디케이터로 변경할것
+                self?.registerButton.isEnabled = false
+                self?.viewModel.requestRegister()
+            })
+            .disposed(by: disposeBag)
     }
     
     private func updateValidate(_ isValidate: Bool) {

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -25,6 +25,8 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
     private let registerGifticonView = RegisterGifticonView()
     private let registerButton = DDIPCTAButton()
     
+    private let toastView = ToastView()
+    
     private let disposeBag = DisposeBag()
     
     override func configure() {
@@ -75,6 +77,18 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
         viewModel.informationValidate
             .subscribe(onNext: { [weak self] in
                 self?.updateValidate($0)
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.toast
+            .subscribe(onNext: { [weak self] in
+                switch $0 {
+                case .registerSuccess:
+                    self?.showRegisterSuccessToast()
+                case .registerFail:
+                    self?.showRegisterFailToast()
+                }
+                self?.registerButton.isEnabled = true
             })
             .disposed(by: disposeBag)
         
@@ -239,5 +253,19 @@ extension RegisterGifticonViewController: RegisterGifticonImageViewButtonDelegat
         let gifticonImageViewController = GiftionImageViewController()
         gifticonImageViewController.giftionImageView.image = viewModel.gifticonImage
         present(gifticonImageViewController, animated: true)
+    }
+}
+
+// MARK: - Toast
+
+extension RegisterGifticonViewController {
+    private func showRegisterSuccessToast() {
+        toastView.configureToastView(with: self.view, style: .register, image: .iconLogoCharacter)
+        toastView.showToastView(with: self.view)
+    }
+    
+    private func showRegisterFailToast() {
+        toastView.configureToastView(with: self.view, style: .registerFail, image: .iconRotateLogoCharacterEmpty)
+        toastView.showToastView(with: self.view)
     }
 }

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -236,7 +236,7 @@ extension RegisterGifticonViewController: UIScrollViewDelegate {
 // MARK: - Picker
 
 extension RegisterGifticonViewController {
-    func showPicker() {
+    private func showPicker() {
         let pickerViewController = PickerViewController(PickerViewModel(dataSourceType: .title(
             // TODO: - 임의로 넣은 피커 데이터. 확인 필요
             ["30분", "1시간", "1시간30분", "2시간", "2시간 30분"]

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -71,6 +71,37 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
                 self?.registerGifticonView.updateCategories($0)
             })
             .disposed(by: disposeBag)
+        
+        viewModel.informationValidate
+            .subscribe(onNext: { [weak self] in
+                self?.updateValidate($0)
+            })
+            .disposed(by: disposeBag)
+        
+        registerGifticonView.selectedCategoryIndex = { [weak self] in
+            self?.viewModel.update(.category($0))
+        }
+        
+        registerGifticonView.updateBarandName = { [weak self] in
+            self?.viewModel.update(.brandName($0))
+        }
+        
+        registerGifticonView.updateProductName = { [weak self] in
+            self?.viewModel.update(.productName($0))
+        }
+        
+        registerGifticonView.updateExpirationDate = { [weak self] in
+            self?.viewModel.update(.expirationDate($0))
+        }
+        
+        registerGifticonView.updateDeadLineMinute = { [weak self] in
+            self?.viewModel.update(.deadLineMinute($0))
+        }
+    }
+    
+    private func updateValidate(_ isValidate: Bool) {
+        registerButton.isEnabled = isValidate
+        updateRegisterButton(isValidate)
     }
 }
 
@@ -110,8 +141,12 @@ extension RegisterGifticonViewController {
     }
     
     private func configureRegisterButton() {
-        registerButton.setTitle(title: "내용을 입력해야 뿌릴 수 있어요")
-        registerButton.setBackgroundColor(buttonColor: .secondarySkyblue200)
+        updateRegisterButton()
+    }
+    
+    private func updateRegisterButton(_ isValidate: Bool = false) {
+        registerButton.setTitle(title: isValidate ? "기프티콘을 뿌려볼까요?" : "내용을 입력해야 뿌릴 수 있어요")
+        registerButton.setBackgroundColor(buttonColor: isValidate ? .secondaryBlue : .secondarySkyblue200)
     }
 }
 

--- a/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
@@ -14,15 +14,28 @@ import RxSwift
 protocol RegisterGifticonViewModelProtocol {
     var gifticonImage: UIImage { get set }
     var categories: BehaviorRelay<[String]> { get }
+    var informationValidate: PublishRelay<Bool> { get }
+    
+    func update(_ type: RegisterGifticonViewModel.Update)
 }
 
 final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
+    enum Update {
+        case category(Int)
+        case brandName(String?)
+        case productName(String?)
+        case expirationDate(String?)
+        case deadLineMinute(String?)
+    }
     private let network: Networking
     private lazy var service = GifticonService(network: network)
     private let disposeBag = DisposeBag()
     
     var gifticonImage: UIImage
     var categories = BehaviorRelay<[String]>(value: [])
+    var informationValidate = PublishRelay<Bool>()
+    
+    private var information = SprinkleInformation()
     
     init(network: Networking, gifticonImage: UIImage) {
         self.network = network
@@ -38,5 +51,27 @@ final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
                 self?.categories.accept(cateogires)
             })
             .disposed(by: disposeBag)
+    }
+    
+    func update(_ type: Update) {
+        switch type {
+        case let .category(index):
+            let category = categories.value[index]
+            information.category = category
+        case let .brandName(name):
+            information.brandName = name
+        case let .productName(name):
+            information.productName = name
+        case let .expirationDate(date):
+            information.expirationDate = date
+        case let .deadLineMinute(minute):
+            information.deadLineMinute = minute
+        }
+        
+        checkValidation()
+    }
+    
+    private func checkValidation() {
+        informationValidate.accept(information.isValidate())
     }
 }

--- a/Projects/App/Sources/Register/View/RegisterGifticonDDipInfoView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonDDipInfoView.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 import DesignSystem
+import RxSwift
 import SnapKit
 
 /// 기프티콘 정보 - 기프티콘 뿌리기 정보 뷰
@@ -29,7 +30,19 @@ final class RegisterGifticonDDipInfoView: BaseView {
         placeholder: "마감시간을 선택해주세요"
     )
     
+    private let disposeBag = DisposeBag()
+    
     var didTapTimeSelect: (() -> ())?
+    var didUpdateDeadLineMinute: ((String?) -> ())?
+    
+    override func configure() {
+        super.configure()
+        timeInputView.textRelay
+            .subscribe(onNext: { [weak self] in
+                self?.didUpdateDeadLineMinute?($0)
+            })
+            .disposed(by: disposeBag)
+    }
     
     override func setLayout() {
         super.setLayout()

--- a/Projects/App/Sources/Register/View/RegisterGifticonInfoView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonInfoView.swift
@@ -36,7 +36,7 @@ final class RegisterGifticonInfoView: BaseView {
         return collectionView
     }()
     
-    private let barndInputView = DDIPInputView(title: "브랜드", placeholder: "브랜드명을 입력해주세요")
+    private let brandInputView = DDIPInputView(title: "브랜드", placeholder: "브랜드명을 입력해주세요")
     private let nameInputView = DDIPInputView(title: "제품명", placeholder: "제품명을 입력해주세요")
     private let expirationDateInputView = DDIPInputView(inputType: .text,
                                                              title: "유효기간",
@@ -97,6 +97,11 @@ final class RegisterGifticonInfoView: BaseView {
         return stackView
     }()
     
+    var didSelectCategory: ((Int) -> ())?
+    var didUpdateBrandName: ((String?) -> ())?
+    var didUpdateProductName: ((String?) -> ())?
+    var didUpdateExpirationDate: ((String?) -> ())?
+    
     override func setLayout() {
         super.setLayout()
         
@@ -114,7 +119,7 @@ final class RegisterGifticonInfoView: BaseView {
         stackView.setCustomSpacing(24, after: categoryView)
         
         inputStackView.addArrangedSubviews(with: [
-            barndInputView,
+            brandInputView,
             nameInputView,
             expirationDateInputView
         ])
@@ -141,6 +146,24 @@ final class RegisterGifticonInfoView: BaseView {
             .subscribe(onNext: { [weak self] in
                 guard let size = $0, size.height != .zero else { return }
                 self?.updateCategoryViewHeight(size.height)
+            })
+            .disposed(by: disposeBag)
+        
+        brandInputView.textRelay
+            .subscribe(onNext: { [weak self] in
+                self?.didUpdateBrandName?($0)
+            })
+            .disposed(by: disposeBag)
+        
+        nameInputView.textRelay
+            .subscribe(onNext: { [weak self] in
+                self?.didUpdateProductName?($0)
+            })
+            .disposed(by: disposeBag)
+        
+        expirationDateInputView.textRelay
+            .subscribe(onNext: { [weak self] in
+                self?.didUpdateExpirationDate?($0)
             })
             .disposed(by: disposeBag)
         
@@ -173,6 +196,7 @@ extension RegisterGifticonInfoView: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) as? CategoryCollectionViewCell else { return }
         cell.updateButton(isSelected: true)
+        didSelectCategory?(indexPath.row)
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {

--- a/Projects/App/Sources/Register/View/RegisterGifticonView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonView.swift
@@ -19,6 +19,11 @@ final class RegisterGifticonView: BaseView {
     private let ddipInfoView = RegisterGifticonDDipInfoView()
     
     var showTimeSelectPicker: (() -> ())?
+    var selectedCategoryIndex: ((Int) -> ())?
+    var updateBarandName: ((String?) -> ())?
+    var updateProductName: ((String?) -> ())?
+    var updateExpirationDate: ((String?) -> ())?
+    var updateDeadLineMinute: ((String?) -> ())?
     
     override func setLayout() {
         super.setLayout()
@@ -56,6 +61,26 @@ final class RegisterGifticonView: BaseView {
         
         ddipInfoView.didTapTimeSelect = { [weak self] in
             self?.showTimeSelectPicker?()
+        }
+        
+        gifticonInfoView.didSelectCategory = { [weak self] in
+            self?.selectedCategoryIndex?($0)
+        }
+        
+        gifticonInfoView.didUpdateBrandName = { [weak self] in
+            self?.updateBarandName?($0)
+        }
+        
+        gifticonInfoView.didUpdateProductName = { [weak self] in
+            self?.updateProductName?($0)
+        }
+        
+        gifticonInfoView.didUpdateExpirationDate = { [weak self] in
+            self?.updateExpirationDate?($0)
+        }
+        
+        ddipInfoView.didUpdateDeadLineMinute = { [weak self] in
+            self?.updateDeadLineMinute?($0)
         }
     }
 }

--- a/Projects/App/Sources/Usecase/SprinkleInformation.swift
+++ b/Projects/App/Sources/Usecase/SprinkleInformation.swift
@@ -1,0 +1,31 @@
+//
+//  SprinkleInformation.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/08.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import UIKit
+
+struct SprinkleInformation {
+    var category: String?
+    var brandName: String?
+    var productName: String?
+    var expirationDate: String?
+    var deadLineMinute: String?
+    
+    func isValidate() -> Bool {
+        if
+            let category = category, category.isEmpty == false,
+            let brandName = brandName, brandName.isEmpty == false,
+            let productName = productName, productName.isEmpty == false,
+            let expirationDate = expirationDate, expirationDate.isEmpty == false,
+            let deadLineMinute = deadLineMinute, deadLineMinute.isEmpty == false
+        {
+            return true
+        }
+        
+        return false
+    }
+}

--- a/Projects/App/Sources/Usecase/SprinkleInformation.swift
+++ b/Projects/App/Sources/Usecase/SprinkleInformation.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 struct SprinkleInformation {
+    let image: UIImage
     var category: String?
     var brandName: String?
     var productName: String?
@@ -27,5 +28,14 @@ struct SprinkleInformation {
         }
         
         return false
+    }
+    
+    func intDeadLineMinute() -> Int {
+        if let deadLineMinute = deadLineMinute, deadLineMinute.isEmpty == false {
+            // TODO: 분, 시간 -> 분으로 변경하는 로직 추가하기
+            return 30
+        }
+        
+        return .zero
     }
 }

--- a/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
+++ b/Projects/DesignSystem/Sources/Component/InputField/DDIPInputField.swift
@@ -42,7 +42,8 @@ public final class DDIPInputField: UIView {
     
     private var disposeBag = DisposeBag()
     
-    let state = PublishRelay<DDIPInputField.State>()
+    public let state = PublishRelay<DDIPInputField.State>()
+    public let textRelay = BehaviorRelay<String?>(value: nil)
     
     // MARK: - Property Observers
     
@@ -79,7 +80,9 @@ public final class DDIPInputField: UIView {
         bind()
         
         update(placeholder: placeholder)
-        update(condition: condition)
+        if let condition = condition {
+            update(condition: condition)
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -119,6 +122,11 @@ extension DDIPInputField {
 extension DDIPInputField {
     private func bind() {
         disposeBag = DisposeBag()
+        
+        textfield.rx.text
+            .distinctUntilChanged()
+            .bind(to: textRelay)
+            .disposed(by: disposeBag)
         
         if condition != nil {
             bindCheck()
@@ -225,6 +233,7 @@ extension DDIPInputField {
     
     public func update(text: String?) {
         self.text = text
+        self.textRelay.accept(text)
     }
     
     public func update(keyboardType: UIKeyboardType) {

--- a/Projects/DesignSystem/Sources/Component/InputView/DDIPInputView.swift
+++ b/Projects/DesignSystem/Sources/Component/InputView/DDIPInputView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+import RxRelay
 import RxSwift
 
 public final class DDIPInputView: UIView {
@@ -49,6 +50,8 @@ public final class DDIPInputView: UIView {
     // MARK: - Binding Property
     
     private var disposeBag = DisposeBag()
+    
+    public let textRelay = BehaviorRelay<String?>(value: nil)
     
     // MARK: - Property Observers
     
@@ -114,7 +117,10 @@ public final class DDIPInputView: UIView {
         update(inputType: inputType)
         update(title: title)
         update(placeholder: placeholder)
-        update(condition: condition)
+        
+        if let condition = condition {
+            update(condition: condition)
+        }
     }
     
     required init?(coder: NSCoder) {
@@ -145,6 +151,10 @@ extension DDIPInputView: AddViewsable {
 extension DDIPInputView {
     private func bind() {
         disposeBag = DisposeBag()
+        
+        inputField.textRelay
+            .bind(to: textRelay)
+            .disposed(by: disposeBag)
         
         bindActionButton()
         bindInputFieldState()

--- a/Projects/DesignSystem/Sources/Component/ToastView/DDIPToastView.swift
+++ b/Projects/DesignSystem/Sources/Component/ToastView/DDIPToastView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class DDIPToastView: UIView, AddViewsable {
     public enum ToastViewOptions {
-        case save, register, apply
+        case save, register, registerFail, apply
 
         var info: (title: String, description: String) {
             switch self {
@@ -18,6 +18,8 @@ public class DDIPToastView: UIView, AddViewsable {
                 return ("저장완료", "기프티콘이 갤러리에 저장되었어요.")
             case .register:
                 return ("등록 완료", "뿌리기 등록이 완료되었어요!\n 설정한 마감 시간이 지나면 자동적으로 기프티콘이 전달됩니다.")
+            case .registerFail:
+                return ("등록 실패", "다시 한 번 시도해주세요.")
             case .apply:
                 return ("응모 완료", "응모가 완료되었어요!\n 응모 결과는 마감 후에 확인할 수 있어요.")
             }


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve #100 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
https://github.com/mash-up-kr/GGiriGGiri_iOS/pull/108  작업에 이은 뿌리기 등록화면 작업입니다.

* b8d1a8641503122a003cc4f684714442320d3a40 커밋에서 data가 오지않는 response에 대한 base를 추가하여 분기처리 하였습니다.
    * API를 추가하는 작업을 진행한 경우 해당 커밋을 cherrypick 해주시길 부탁드립니다. (@kimkyunghun3 , @ios-h)
* 0a321a9e798946f12b69c755e7cc3a042bf40413 커밋에서 기존의 `DDIPInputfield`, `DDIPInputView`가 입력한 text에 대한 binding이 없어 추가하였습니다.
* 46666e5e529d299374cbc87b9c6071d3bff6c773 커밋에서 뿌리기 등록 API 연동을 진행했습니다. 다만 테스트 영상의 경우 mock 데이터가 내려오므로 실제 연동은 다시 한번 확인할 필요가 있습니다.
* 4a3b6d840281ef4ad8a0327e2967033acdceb3f1 커밋에서 DDIPToastView에 대한 케이스를 추가하였습니다.
* 4af507dec0a72fde8284e99bcf372178eff556d2 커밋에서 뿌리기 등록 API에 대한 결과 toast를 띄우는 기능을 추가하였습니다.

### 미리보기
<!-- 작업 전/후 스크린샷으로 표현하기 어려울 경우 영상을 첨부합니다. -->

작업 후

https://user-images.githubusercontent.com/39300449/183575968-37a47932-612f-4830-a746-3fef4ed23ebb.mp4


