### PR TITLE
[DA] CategoryAPI 네트워크 분리 및 Repository Layer 적용

### DIFF
--- a/Projects/App/Sources/Common/Model/Category.swift
+++ b/Projects/App/Sources/Common/Model/Category.swift
@@ -9,14 +9,25 @@
 import Foundation
 
 enum Category: String, CaseIterable {
-    case all = "전체"
-    case cafe = "카페/디저트"
-    case delivery = "치킨/배달음식"
-    case icecream = "아이스크림"
-    case store = "편의점"
-    case fastfood = "패스트푸드"
-    case certificate = "상품권"
-    case etc = "기타"
+    case all = "ALL"
+    case cafe = "CAFE"
+    case delivery = "DELIVERY"
+    case icecream = "ICECREAM"
+    case convenienceStore = "CONVENIENCE_STORE"
+    case fastfood = "FAST_FOOD"
+    case voucher = "VOUCHER"
+    case etc = "ETC"
     
-    static let register: [Category] = Category.allCases.filter { return $0 != Category.all }
+    var description: String {
+        switch self {
+        case .all: return "전체"
+        case .cafe: return "카페/디저트"
+        case .delivery: return "배달음식"
+        case .icecream: return "아이스크림"
+        case .convenienceStore: return "편의점"
+        case .fastfood: return "패스트푸드"
+        case .voucher: return "상품권"
+        case .etc: return "기타"
+        }
+    }
 }

--- a/Projects/App/Sources/Driver/Networking/ResponseModel/CategoryResponseModel.swift
+++ b/Projects/App/Sources/Driver/Networking/ResponseModel/CategoryResponseModel.swift
@@ -1,0 +1,20 @@
+//
+//  CategoryResponseModel.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/09.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import Foundation
+
+enum CategoryResponseModel: String, Decodable, CaseIterable {
+    case all = "ALL"
+    case cafe = "CAFE"
+    case delivery = "DELIVERY"
+    case icecream = "ICECREAM"
+    case convenienceStore = "CONVENIENCE_STORE"
+    case fastFood = "FAST_FOOD"
+    case voucher = "VOUCHER"
+    case etc = "ETC"
+}

--- a/Projects/App/Sources/Driver/Repository/CategoryRepository.swift
+++ b/Projects/App/Sources/Driver/Repository/CategoryRepository.swift
@@ -9,13 +9,13 @@
 import RxRelay
 import RxSwift
 
-protocol CategotyRespositoryLogic {
+protocol CategoryRepositoryLogic {
     var categoryEntity: BehaviorRelay<CategoryEntity> { get }
     
     func fetchCategories()
 }
 
-final class CategoryRepository: CategotyRespositoryLogic {
+final class CategoryRepository: CategoryRepositoryLogic {
     private let disposeBag = DisposeBag()
     private let categoryService: CategoryServiceLogic
     

--- a/Projects/App/Sources/Driver/Repository/CategoryRepository.swift
+++ b/Projects/App/Sources/Driver/Repository/CategoryRepository.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 dvHuni. All rights reserved.
 //
 
-import RxSwift
 import RxRelay
+import RxSwift
 
 protocol CategotyRespositoryProtocol {
     var categoryEntity: BehaviorRelay<CategoryEntity> { get }

--- a/Projects/App/Sources/Driver/Repository/CategoryRepository.swift
+++ b/Projects/App/Sources/Driver/Repository/CategoryRepository.swift
@@ -1,0 +1,32 @@
+//
+//  CategoryRepository.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/09.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import RxSwift
+import RxRelay
+
+protocol CategotyRespositoryProtocol {
+    var categoryEntity: BehaviorRelay<CategoryEntity> { get }
+    
+    func fetchCategories()
+}
+
+final class CategoryRepository: CategotyRespositoryProtocol {
+    private let disposeBag = DisposeBag()
+    private let categoryService = CategoryService(network: Network())
+    
+    var categoryEntity = BehaviorRelay<CategoryEntity>(value: CategoryEntity())
+    
+    func fetchCategories() {
+        categoryService.categories()
+            .subscribe(onSuccess: { [weak self] in
+                guard let categoriesModel = $0.data else { return }
+                self?.categoryEntity.accept(CategoryEntity(categoriesModel))
+            })
+            .disposed(by: disposeBag)
+    }
+}

--- a/Projects/App/Sources/Driver/Repository/CategoryRepository.swift
+++ b/Projects/App/Sources/Driver/Repository/CategoryRepository.swift
@@ -9,17 +9,21 @@
 import RxRelay
 import RxSwift
 
-protocol CategotyRespositoryProtocol {
+protocol CategotyRespositoryLogic {
     var categoryEntity: BehaviorRelay<CategoryEntity> { get }
     
     func fetchCategories()
 }
 
-final class CategoryRepository: CategotyRespositoryProtocol {
+final class CategoryRepository: CategotyRespositoryLogic {
     private let disposeBag = DisposeBag()
-    private let categoryService = CategoryService(network: Network())
+    private let categoryService: CategoryServiceLogic
     
     var categoryEntity = BehaviorRelay<CategoryEntity>(value: CategoryEntity())
+    
+    init(_ categoryService: CategoryServiceLogic) {
+        self.categoryService = categoryService
+    }
     
     func fetchCategories() {
         categoryService.categories()

--- a/Projects/App/Sources/Driver/Service/Category/CategoryAPI.swift
+++ b/Projects/App/Sources/Driver/Service/Category/CategoryAPI.swift
@@ -1,0 +1,24 @@
+//
+//  CategoryAPI.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/09.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import Foundation
+
+import Alamofire
+
+enum CategoryAPI {
+    case categories
+}
+
+extension CategoryAPI: NetworkRequestable {
+    var path: String {
+        switch self {
+        case .categories:
+            return "/api/v1/coupon/category"
+        }
+    }
+}

--- a/Projects/App/Sources/Driver/Service/Category/CategoryService.swift
+++ b/Projects/App/Sources/Driver/Service/Category/CategoryService.swift
@@ -10,9 +10,13 @@ import Foundation
 
 import RxSwift
 
-struct CategoryService {
+protocol CategoryServiceLogic {
     typealias CategoryListResponse = ResponseData<[CategoryResponseModel]>
     
+    func categories() -> CategoryListResponse
+}
+
+struct CategoryService: CategoryServiceLogic {
     private let network: Networking
     
     init(network: Networking) {

--- a/Projects/App/Sources/Driver/Service/Category/CategoryService.swift
+++ b/Projects/App/Sources/Driver/Service/Category/CategoryService.swift
@@ -1,0 +1,25 @@
+//
+//  CategoryService.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/09.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import Foundation
+
+import RxSwift
+
+struct CategoryService {
+    typealias CategoryListResponse = ResponseData<[CategoryResponseModel]>
+    
+    private let network: Networking
+    
+    init(network: Networking) {
+        self.network = network
+    }
+    
+    func categories() -> CategoryListResponse {
+        network.request(CategoryAPI.categories).map()
+    }
+}

--- a/Projects/App/Sources/Driver/Service/GifticonAPI.swift
+++ b/Projects/App/Sources/Driver/Service/GifticonAPI.swift
@@ -11,7 +11,6 @@ import Foundation
 import Alamofire
 
 enum GifticonAPI {
-    case categories
     case categoryList(GifticonListRequestModel)
     case registerSprinkle(SprinkleRegisterRequestModel)
 }
@@ -19,8 +18,6 @@ enum GifticonAPI {
 extension GifticonAPI: NetworkRequestable {
     var path: String {
         switch self {
-        case .categories:
-            return "/api/v1/coupon/category"
         case .categoryList:
             return "/api/v1/sprinkles"
         case .registerSprinkle:
@@ -30,7 +27,7 @@ extension GifticonAPI: NetworkRequestable {
     
     var method: HTTPMethod {
         switch self {
-        case .categories, .categoryList:
+        case .categoryList:
             return .get
         case .registerSprinkle:
             return .post
@@ -39,8 +36,6 @@ extension GifticonAPI: NetworkRequestable {
     
     var parameters: Encodable? {
         switch self {
-        case .categories:
-            return nil
         case let .categoryList(model):
             return model
         case let .registerSprinkle(model):
@@ -50,7 +45,7 @@ extension GifticonAPI: NetworkRequestable {
     
     var headers: HTTPHeaders {
         switch self {
-        case .categories, .categoryList:
+        case .categoryList:
             return .default
         case .registerSprinkle:
             return .multipartHeader

--- a/Projects/App/Sources/Driver/Service/GifticonService.swift
+++ b/Projects/App/Sources/Driver/Service/GifticonService.swift
@@ -11,7 +11,6 @@ import Foundation
 import RxSwift
 
 struct GifticonService {
-    typealias CategoryListResponse = ResponseData<[String]>
     typealias CouponListResponse = ResponseData<[CouponEntity]>
     typealias RegisterSprinkleResponse = Response
     
@@ -19,10 +18,6 @@ struct GifticonService {
     
     init(network: Networking) {
         self.network = network
-    }
-    
-    func categories() -> CategoryListResponse {
-        network.request(GifticonAPI.categories).map()
     }
     
     func list(_ model: GifticonListRequestModel) -> CouponListResponse {

--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -104,7 +104,10 @@ extension MainViewModel: PHPickerViewControllerDelegate {
                     }
                     
                     self.alert?(nil, "쿠폰 이미지 분석 중~", nil, nil, { _ in
-                        let viewModel = RegisterGifticonViewModel(network: Network(), gifticonImage: image)
+                        let viewModel = RegisterGifticonViewModel(
+                            network: Network(),
+                            categoryRepository: CategoryRepository(),
+                            gifticonImage: image)
                         let registerGifticonViewController = RegisterGifticonViewController(viewModel)
                         registerGifticonViewController.modalPresentationStyle = .fullScreen
                         self.present?(registerGifticonViewController)

--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -106,7 +106,7 @@ extension MainViewModel: PHPickerViewControllerDelegate {
                     self.alert?(nil, "쿠폰 이미지 분석 중~", nil, nil, { _ in
                         let viewModel = RegisterGifticonViewModel(
                             network: Network(),
-                            categoryRepository: CategoryRepository(),
+                            categoryRepository: CategoryRepository(CategoryService(network: Network())),
                             gifticonImage: image)
                         let registerGifticonViewController = RegisterGifticonViewController(viewModel)
                         registerGifticonViewController.modalPresentationStyle = .fullScreen

--- a/Projects/App/Sources/Main/View/CategoryCollectionViewCell.swift
+++ b/Projects/App/Sources/Main/View/CategoryCollectionViewCell.swift
@@ -63,11 +63,6 @@ final class CategoryCollectionViewCell: UICollectionViewCell {
         nameLabel.clipsToBounds = true
         
         categoryType = Category.allCases[index]
-        
-        if category == Category.register {
-            nameLabel.text = Category.register[index].rawValue
-            return
-        }
         nameLabel.text = Category.allCases[index].rawValue
     }
 }

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -66,11 +66,12 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
     
     override func bind() {
         super.bind()
-        
-        viewModel.categories
+        viewModel.categoryRepository?.categoryEntity
             .skip(1)
             .subscribe(onNext: { [weak self] in
-                self?.registerGifticonView.updateCategories($0)
+                self?.registerGifticonView.updateCategories(
+                    $0.expectAll.map { $0.description }
+                )
             })
             .disposed(by: disposeBag)
         

--- a/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
@@ -12,7 +12,7 @@ import RxRelay
 import RxSwift
 
 protocol RegisterGifticonViewModelProtocol {
-    var categoryRepository: CategotyRespositoryProtocol? { get }
+    var categoryRepository: CategotyRespositoryLogic? { get }
     
     var gifticonImage: UIImage { get }
     var informationValidate: PublishRelay<Bool> { get }
@@ -35,8 +35,9 @@ final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
         case registerFail
     }
     
-    var categoryRepository: CategotyRespositoryProtocol?
+    var categoryRepository: CategotyRespositoryLogic?
     
+    // TODO: Gifticon API 리팩토링 후 제거할것
     private let network: Networking
     private lazy var service = GifticonService(network: network)
     private let disposeBag = DisposeBag()
@@ -49,7 +50,7 @@ final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
     
     private var information: SprinkleInformation
     
-    init(network: Networking, categoryRepository: CategotyRespositoryProtocol, gifticonImage: UIImage) {
+    init(network: Networking, categoryRepository: CategotyRespositoryLogic, gifticonImage: UIImage) {
         self.network = network
         self.categoryRepository = categoryRepository
         self.information = SprinkleInformation(image: gifticonImage)

--- a/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
@@ -12,8 +12,9 @@ import RxRelay
 import RxSwift
 
 protocol RegisterGifticonViewModelProtocol {
+    var categoryRepository: CategotyRespositoryProtocol? { get }
+    
     var gifticonImage: UIImage { get }
-    var categories: BehaviorRelay<[String]> { get }
     var informationValidate: PublishRelay<Bool> { get }
     var toast: PublishRelay<RegisterGifticonViewModel.Toast> { get }
     
@@ -33,6 +34,9 @@ final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
         case registerSuccess
         case registerFail
     }
+    
+    var categoryRepository: CategotyRespositoryProtocol?
+    
     private let network: Networking
     private lazy var service = GifticonService(network: network)
     private let disposeBag = DisposeBag()
@@ -40,24 +44,29 @@ final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
     var gifticonImage: UIImage {
         information.image
     }
-    var categories = BehaviorRelay<[String]>(value: [])
     var informationValidate = PublishRelay<Bool>()
     var toast = PublishRelay<Toast>()
     
     private var information: SprinkleInformation
     
-    init(network: Networking, gifticonImage: UIImage) {
+    init(network: Networking, categoryRepository: CategotyRespositoryProtocol, gifticonImage: UIImage) {
         self.network = network
+        self.categoryRepository = categoryRepository
         self.information = SprinkleInformation(image: gifticonImage)
         
-        fetchCategories()
+        configure()
     }
     
+    private func configure() {
+        categoryRepository?.fetchCategories()
+    }
     
     func update(_ type: Update) {
         switch type {
         case let .category(index):
-            let category = categories.value[index]
+            guard
+                let category = categoryRepository?.categoryEntity.value.expectAll[index].rawValue
+            else { return }
             information.category = category
         case let .brandName(name):
             information.brandName = name
@@ -80,15 +89,6 @@ final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
 // MARK: - Networkings
 
 extension RegisterGifticonViewModel {
-    func fetchCategories() {
-        service.categories()
-            .subscribe(onSuccess: { [weak self] in
-                guard let cateogires = $0.data else { return }
-                self?.categories.accept(cateogires)
-            })
-            .disposed(by: disposeBag)
-    }
-    
     func requestRegister() {
         service.registerSprinkle(information)
             .subscribe(onSuccess: { [weak self] in

--- a/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
@@ -12,7 +12,7 @@ import RxRelay
 import RxSwift
 
 protocol RegisterGifticonViewModelProtocol {
-    var categoryRepository: CategotyRespositoryLogic? { get }
+    var categoryRepository: CategotyRepositoryLogic? { get }
     
     var gifticonImage: UIImage { get }
     var informationValidate: PublishRelay<Bool> { get }
@@ -35,7 +35,7 @@ final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
         case registerFail
     }
     
-    var categoryRepository: CategotyRespositoryLogic?
+    var categoryRepository: CategotyRepositoryLogic?
     
     // TODO: Gifticon API 리팩토링 후 제거할것
     private let network: Networking
@@ -50,7 +50,7 @@ final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
     
     private var information: SprinkleInformation
     
-    init(network: Networking, categoryRepository: CategotyRespositoryLogic, gifticonImage: UIImage) {
+    init(network: Networking, categoryRepository: CategotyRepositoryLogic, gifticonImage: UIImage) {
         self.network = network
         self.categoryRepository = categoryRepository
         self.information = SprinkleInformation(image: gifticonImage)

--- a/Projects/App/Sources/Usecase/CategoryEntity.swift
+++ b/Projects/App/Sources/Usecase/CategoryEntity.swift
@@ -1,0 +1,25 @@
+//
+//  CategoryEntity.swift
+//  GGiriGGiri
+//
+//  Created by AhnSangHoon on 2022/08/09.
+//  Copyright © 2022 dvHuni. All rights reserved.
+//
+
+import Foundation
+
+struct CategoryEntity {
+    private var values: [Category] = []
+    
+    var all: [Category] {
+        values
+    }
+    
+    var expectAll: [Category] {
+        values.filter { $0 != .all }
+    }
+    
+    init(_ categoriesModel: [CategoryResponseModel] = []) {
+        values = categoriesModel.compactMap { Category(rawValue: $0.rawValue) }
+    }
+}


### PR DESCRIPTION
# 개요

# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* 카테고리 API를 기프티콘 API에서 분리하였습니다.
* ResponseModel을 Entity로 변환하고, 앱에서 사용하는 Model로 변환해주는 Repository Layer를 적용하였습니다.
* 이후에 해당 작업을 참고하여 다른 API들을 리팩터링 할 예정입니다. 
* 참고 :  https://github.com/mash-up-kr/GGiriGGiri_iOS/pull/26

### 미리보기
<!-- 작업 전/후 스크린샷으로 표현하기 어려울 경우 영상을 첨부합니다. -->

작업 후
<!-- 영상 -->

https://user-images.githubusercontent.com/39300449/183822778-2a519db0-2037-4038-9ad3-3bfcafdc5844.mp4


