### PR TITLE
[DA] 타이머 시간이 0이 되었을 때 처리 추가

### DIFF
--- a/Projects/App/Sources/Apply/ApplyViewController.swift
+++ b/Projects/App/Sources/Apply/ApplyViewController.swift
@@ -106,7 +106,7 @@ final class ApplyViewController: BaseViewController<ApplyViewModelProtocol> {
             })
             .disposed(by: disposeBag)
         
-        applyGifticonView.countDownTimeOver
+        applyGifticonView.countdownTimeOver
             .subscribe(onNext: { [weak self] in
                 self?.alert(
                     title: "응모 마감",

--- a/Projects/App/Sources/Apply/ApplyViewController.swift
+++ b/Projects/App/Sources/Apply/ApplyViewController.swift
@@ -105,6 +105,18 @@ final class ApplyViewController: BaseViewController<ApplyViewModelProtocol> {
 
             })
             .disposed(by: disposeBag)
+        
+        applyGifticonView.countDownTimeOver
+            .subscribe(onNext: { [weak self] in
+                self?.alert(
+                    title: "응모 마감",
+                    message: "응모 가능시간이 초과되었습니다.",
+                    okTitle: "뒤로",
+                    cancelHandler: nil) { _ in
+                        self?.navigationController?.popViewController(animated: true)
+                    }
+            })
+            .disposed(by: disposeBag)
     }
 
     override func setLayout() {

--- a/Projects/App/Sources/Apply/View/ApplyGifticonView.swift
+++ b/Projects/App/Sources/Apply/View/ApplyGifticonView.swift
@@ -107,6 +107,6 @@ final class ApplyGifticonView: BaseView {
     }
 
     func setExpirationDate(name: String) {
-        applyInformationView.setExpirationDateLabelView(name.format(.yearMonthDay))
+        applyInformationView.setExpirationDateLabelView(name.format(.dotYearMonthDay))
     }
 }

--- a/Projects/App/Sources/Apply/View/ApplyGifticonView.swift
+++ b/Projects/App/Sources/Apply/View/ApplyGifticonView.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 import DesignSystem
+import RxRelay
+import RxSwift
 import SnapKit
 
 /// 기프티콘 응모 뷰
@@ -36,6 +38,17 @@ final class ApplyGifticonView: BaseView {
         label.textAlignment = .center
         return label
     }()
+    
+    private let disposeBag = DisposeBag()
+    let countDownTimeOver = PublishRelay<Void>()
+    
+    override func configure() {
+        super.configure()
+        
+        countdownView.countDownTimeOver
+            .bind(to: countDownTimeOver)
+            .disposed(by: disposeBag)
+    }
     
     override func setLayout() {
         super.setLayout()

--- a/Projects/App/Sources/Apply/View/ApplyGifticonView.swift
+++ b/Projects/App/Sources/Apply/View/ApplyGifticonView.swift
@@ -40,13 +40,13 @@ final class ApplyGifticonView: BaseView {
     }()
     
     private let disposeBag = DisposeBag()
-    let countDownTimeOver = PublishRelay<Void>()
+    let countdownTimeOver = PublishRelay<Void>()
     
     override func configure() {
         super.configure()
         
-        countdownView.countDownTimeOver
-            .bind(to: countDownTimeOver)
+        countdownView.countdownTimeOver
+            .bind(to: countdownTimeOver)
             .disposed(by: disposeBag)
     }
     

--- a/Projects/App/Sources/Driver/Extension/Encodable+Alamofire.swift
+++ b/Projects/App/Sources/Driver/Extension/Encodable+Alamofire.swift
@@ -32,10 +32,13 @@ extension Encodable {
             
             var dictionary: [String: Data] = [:]
             for (key, value) in jsonObject {
-                guard let valueString = value as? String else { continue }
-                dictionary.updateValue(Data(base64Encoded: valueString) ?? Data(), forKey: key)
+                if let valueString = value as? String {
+                    dictionary.updateValue(Data(base64Encoded: valueString) ?? Data(), forKey: key)
+                } else {
+                    let serializedData = try? JSONSerialization.data(withJSONObject: value, options: .fragmentsAllowed)
+                    dictionary.updateValue(serializedData ?? Data(), forKey: key)
+                }
             }
-            
             return dictionary
         } catch {
             return [:]

--- a/Projects/App/Sources/Driver/Networking/Networking.swift
+++ b/Projects/App/Sources/Driver/Networking/Networking.swift
@@ -63,13 +63,21 @@ final class Network: Networking {
                 AF.upload(
                     multipartFormData: { multipartFormData in
                         for (key, value) in parameters {
-                            guard key == "image" else { continue }
-                            multipartFormData.append(
-                                value,
-                                withName: "image",
-                                fileName: "file.png",
-                                mimeType: "image/png"
-                            )
+                            if key == "image" {
+                                multipartFormData.append(
+                                    value,
+                                    withName: "image",
+                                    fileName: "file.png",
+                                    mimeType: "image/png"
+                                )
+                            } else {
+                                multipartFormData.append(
+                                    value,
+                                    withName: key,
+                                    fileName: key,
+                                    mimeType: "application/json"
+                                )
+                            }
                         }
                     },
                     to: endpoint,

--- a/Projects/App/Sources/Driver/Repository/OCRRepository.swift
+++ b/Projects/App/Sources/Driver/Repository/OCRRepository.swift
@@ -39,7 +39,7 @@ final class OCRRepository: OCRRepositoryLogic {
                         image: image,
                         brandName: model.brandName,
                         productName: model.productName,
-                        expirationDate: model.expirationDate
+                        expirationDate: model.expirationDate.format(.yearMonthDay)
                     )
                 )
             })

--- a/Projects/App/Sources/Driver/Service/GifticonService.swift
+++ b/Projects/App/Sources/Driver/Service/GifticonService.swift
@@ -44,7 +44,7 @@ struct GifticonService {
     }
     
     func registerSprinkle(_ entity: SprinkleInformation) -> RegisterSprinkleResponse {
-        network.request(
+        network.requestMultipartFormData(
             GifticonAPI.registerSprinkle(
                 SprinkleRegisterRequestModel(entity)
             )

--- a/Projects/App/Sources/Main/MainCollectionViewDataSource.swift
+++ b/Projects/App/Sources/Main/MainCollectionViewDataSource.swift
@@ -18,7 +18,7 @@ final class MainCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     private var gifticonListData: [GifticonCard] = []
     
     var didTapDeadLineApplyButton = PublishRelay<Int>()
-    var didDeadLineCountDownTimeOver = PublishRelay<Void>()
+    var didDeadLineCountdownTimeOver = PublishRelay<Void>()
     
     private let disposeBag = DisposeBag()
     
@@ -52,8 +52,8 @@ final class MainCollectionViewDataSource: NSObject, UICollectionViewDataSource {
             cell.didApplyButtonTapped
                 .bind(to: didTapDeadLineApplyButton)
                 .disposed(by: disposeBag)
-            cell.countDownTimeOver
-                .bind(to: didDeadLineCountDownTimeOver)
+            cell.countdownTimeOver
+                .bind(to: didDeadLineCountdownTimeOver)
                 .disposed(by: disposeBag)
             return cell
         case .category:

--- a/Projects/App/Sources/Main/MainCollectionViewDataSource.swift
+++ b/Projects/App/Sources/Main/MainCollectionViewDataSource.swift
@@ -18,6 +18,7 @@ final class MainCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     private var gifticonListData: [GifticonCard] = []
     
     var didTapDeadLineApplyButton = PublishRelay<Int>()
+    var didDeadLineCountDownTimeOver = PublishRelay<Void>()
     
     private let disposeBag = DisposeBag()
     
@@ -50,6 +51,9 @@ final class MainCollectionViewDataSource: NSObject, UICollectionViewDataSource {
             cell.configure(with: deadlineData)
             cell.didApplyButtonTapped
                 .bind(to: didTapDeadLineApplyButton)
+                .disposed(by: disposeBag)
+            cell.countDownTimeOver
+                .bind(to: didDeadLineCountDownTimeOver)
                 .disposed(by: disposeBag)
             return cell
         case .category:

--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -207,6 +207,12 @@ extension MainViewModel {
                 self?.apply(gifticonId: $0)
             })
             .disposed(by: disposeBag)
+        
+        mainDataSource.didDeadLineCountDownTimeOver
+            .subscribe(onNext: { [weak self] in
+                self?.deadlineInfo()
+            })
+            .disposed(by: disposeBag)
     }
     
     private func requestOCR(_ image: UIImage) {

--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -208,7 +208,7 @@ extension MainViewModel {
             })
             .disposed(by: disposeBag)
         
-        mainDataSource.didDeadLineCountDownTimeOver
+        mainDataSource.didDeadLineCountdownTimeOver
             .subscribe(onNext: { [weak self] in
                 self?.deadlineInfo()
             })

--- a/Projects/App/Sources/Main/View/GifticonDeadLineCollectionViewCell.swift
+++ b/Projects/App/Sources/Main/View/GifticonDeadLineCollectionViewCell.swift
@@ -23,7 +23,7 @@ final class GifticonDeadLineCollectionViewCell: UICollectionViewCell {
     private let cardView = DDIPDeadlineCardView()
     
     let didApplyButtonTapped = PublishRelay<Int>()
-    let countDownTimeOver = PublishRelay<Void>()
+    let countdownTimeOver = PublishRelay<Void>()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -60,8 +60,8 @@ final class GifticonDeadLineCollectionViewCell: UICollectionViewCell {
             .bind(to: didApplyButtonTapped)
             .disposed(by: disposeBag)
         
-        cardView.countDownTimeOver
-            .bind(to: countDownTimeOver)
+        cardView.countdownTimeOver
+            .bind(to: countdownTimeOver)
             .disposed(by: disposeBag)
     }
     

--- a/Projects/App/Sources/Main/View/GifticonDeadLineCollectionViewCell.swift
+++ b/Projects/App/Sources/Main/View/GifticonDeadLineCollectionViewCell.swift
@@ -22,7 +22,8 @@ final class GifticonDeadLineCollectionViewCell: UICollectionViewCell {
     
     private let cardView = DDIPDeadlineCardView()
     
-    var didApplyButtonTapped = PublishRelay<Int>()
+    let didApplyButtonTapped = PublishRelay<Int>()
+    let countDownTimeOver = PublishRelay<Void>()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -57,6 +58,10 @@ final class GifticonDeadLineCollectionViewCell: UICollectionViewCell {
             .withUnretained(self)
             .map { onwer, _ in onwer.gifticonId }
             .bind(to: didApplyButtonTapped)
+            .disposed(by: disposeBag)
+        
+        cardView.countDownTimeOver
+            .bind(to: countDownTimeOver)
             .disposed(by: disposeBag)
     }
     

--- a/Projects/App/Sources/Register/RegisterGifticonViewController.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewController.swift
@@ -87,6 +87,7 @@ final class RegisterGifticonViewController: BaseViewController<RegisterGifticonV
                 switch $0 {
                 case .registerSuccess:
                     self?.showRegisterSuccessToast()
+                    self?.dismissRegister()
                 case .registerFail:
                     self?.showRegisterFailToast()
                 }
@@ -179,6 +180,13 @@ extension RegisterGifticonViewController {
     private func updateRegisterButton(_ isValidate: Bool = false) {
         registerButton.setTitle(title: isValidate ? "기프티콘을 뿌려볼까요?" : "내용을 입력해야 뿌릴 수 있어요")
         registerButton.setBackgroundColor(buttonColor: isValidate ? .secondaryBlue : .secondarySkyblue200)
+    }
+    
+    private func dismissRegister() {
+        // TODO: 임시로 2초 뒤에 동작하게함, Toast의 completion으로 넘겨야함
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
+            self?.dismiss(animated: true)
+        }
     }
 }
 

--- a/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
+++ b/Projects/App/Sources/Register/RegisterGifticonViewModel.swift
@@ -100,7 +100,7 @@ final class RegisterGifticonViewModel: RegisterGifticonViewModelProtocol {
 
 extension RegisterGifticonViewModel {
     func requestRegister() {
-        service.registerSprinkle(information)
+        service.registerSprinkle(information.requestable())
             .subscribe(onSuccess: { [weak self] in
                 // TODO: 에러코드별 처리방법 고도화하기
                 guard $0.code == "S001" else {

--- a/Projects/App/Sources/Usecase/SprinkleInformation.swift
+++ b/Projects/App/Sources/Usecase/SprinkleInformation.swift
@@ -29,7 +29,13 @@ struct SprinkleInformation {
         self.image = image
         self.brandName = brandName
         self.productName = productName
-        self.expirationDate = expirationDate
+        self.expirationDate = expirationDate.format(.yearMonthDay)
+    }
+    
+    mutating
+    func requestable() -> SprinkleInformation {
+        self.expirationDate = expirationDate?.format(.dashYearMonthDay)
+        return self
     }
     
     func isValidate() -> Bool {

--- a/Projects/DesignSystem/Sources/Component/CountdownCard/DDipCountdownCardView.swift
+++ b/Projects/DesignSystem/Sources/Component/CountdownCard/DDipCountdownCardView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+import RxRelay
 import RxSwift
 
 public class DDipCountdownCardView: UIView, AddViewsable {
@@ -87,6 +88,7 @@ public class DDipCountdownCardView: UIView, AddViewsable {
     }()
     
     private var timer = DDIPCountDownTimer(.second)
+    public let countDownTimeOver = PublishRelay<Void>()
     
     private let disposeBag = DisposeBag()
     
@@ -136,6 +138,11 @@ public class DDipCountdownCardView: UIView, AddViewsable {
                 guard let second = $0 else { return }
                 self?.update(second: second)
             })
+            .disposed(by: disposeBag)
+        
+        timer.invalidDate
+            .skip(1)
+            .bind(to: countDownTimeOver)
             .disposed(by: disposeBag)
     }
     

--- a/Projects/DesignSystem/Sources/Component/CountdownCard/DDipCountdownCardView.swift
+++ b/Projects/DesignSystem/Sources/Component/CountdownCard/DDipCountdownCardView.swift
@@ -88,7 +88,7 @@ public class DDipCountdownCardView: UIView, AddViewsable {
     }()
     
     private var timer = DDIPCountDownTimer(.second)
-    public let countDownTimeOver = PublishRelay<Void>()
+    public let countdownTimeOver = PublishRelay<Void>()
     
     private let disposeBag = DisposeBag()
     
@@ -142,7 +142,7 @@ public class DDipCountdownCardView: UIView, AddViewsable {
         
         timer.invalidDate
             .skip(1)
-            .bind(to: countDownTimeOver)
+            .bind(to: countdownTimeOver)
             .disposed(by: disposeBag)
     }
     

--- a/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineCardView.swift
+++ b/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineCardView.swift
@@ -223,7 +223,7 @@ extension DDIPDeadlineCardView {
         imageIcon.image = .designSystem(style.iconImage)
         nameLabel.text = style.name
         brandLabel.text = style.brand
-        expirationLabel.text = "유효기간 : \(style.expirationDate.format(.yearMonthDay))"
+        expirationLabel.text = "유효기간 : \(style.expirationDate.format(.dotYearMonthDay))"
         update(countDownDate: style.time.fullStringDate())
     }
     

--- a/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineCardView.swift
+++ b/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineCardView.swift
@@ -31,6 +31,7 @@ public class DDIPDeadlineCardView: UIView, AddViewsable {
     private let disposeBag = DisposeBag()
     
     public let buttonTapEvent = PublishRelay<Void>()
+    public let countDownTimeOver = PublishRelay<Void>()
     
     private let infoStackView: UIStackView = {
         let stackView = UIStackView()
@@ -194,6 +195,11 @@ public class DDIPDeadlineCardView: UIView, AddViewsable {
                 guard let minute = $0 else { return }
                 self?.update(minute: minute)
             })
+            .disposed(by: disposeBag)
+        
+        timer.invalidDate
+            .skip(1)
+            .bind(to: countDownTimeOver)
             .disposed(by: disposeBag)
     }
     

--- a/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineCardView.swift
+++ b/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineCardView.swift
@@ -31,7 +31,7 @@ public class DDIPDeadlineCardView: UIView, AddViewsable {
     private let disposeBag = DisposeBag()
     
     public let buttonTapEvent = PublishRelay<Void>()
-    public let countDownTimeOver = PublishRelay<Void>()
+    public let countdownTimeOver = PublishRelay<Void>()
     
     private let infoStackView: UIStackView = {
         let stackView = UIStackView()
@@ -199,7 +199,7 @@ public class DDIPDeadlineCardView: UIView, AddViewsable {
         
         timer.invalidDate
             .skip(1)
-            .bind(to: countDownTimeOver)
+            .bind(to: countdownTimeOver)
             .disposed(by: disposeBag)
     }
     

--- a/Projects/DesignSystem/Sources/Component/Extension/String+Date+sugar.swift
+++ b/Projects/DesignSystem/Sources/Component/Extension/String+Date+sugar.swift
@@ -33,7 +33,9 @@ extension Date {
 
 extension String {
     public enum FormatType: String {
-        case yearMonthDay = "YYYY.MM.dd"
+        case yearMonthDay = "YYYYMMDD"
+        case dashYearMonthDay = "YYYY-MM-dd"
+        case dotYearMonthDay = "YYYY.MM.dd"
         case hourMinuteSecond = "HH:mm:SS"
 
         var displayName: String {
@@ -42,7 +44,7 @@ extension String {
     }
 
     public func format(_ type: FormatType) -> String {
-        let dateData = fullStringDate()
+        let dateData = fullStringDate(type)
 
         Formatter.date.dateFormat = type.displayName
         let dateString = Formatter.date.string(from: dateData)
@@ -50,8 +52,17 @@ extension String {
         return dateString
     }
 
-    public func fullStringDate() -> Date {
-        Formatter.date.dateFormat = "yyyy-MM-dd'T'HH:mm"
+    public func fullStringDate(_ type: FormatType = .yearMonthDay) -> Date {
+        var formatString: String {
+            switch type {
+            case .yearMonthDay, .dashYearMonthDay, .hourMinuteSecond:
+                return "yyyy-MM-dd'T'HH:mm"
+            case .dotYearMonthDay:
+                return "yyyy.MM.dd'T'HH:mm"
+            }
+        }
+        
+        Formatter.date.dateFormat = formatString
 
         guard let dateData = Formatter.date.date(from: self) else {
             return Date()

--- a/Projects/DesignSystem/Sources/CountDownTimer/DDIPCountDownTimer.swift
+++ b/Projects/DesignSystem/Sources/CountDownTimer/DDIPCountDownTimer.swift
@@ -45,6 +45,7 @@ public final class DDIPCountDownTimer {
     public let hour = BehaviorRelay<Int?>(value: nil)
     public let minute = BehaviorRelay<Int?>(value: nil)
     public let second = BehaviorRelay<Int?>(value: nil)
+    public let invalidDate = PublishRelay<Void>()
     
     private var disposeBag = DisposeBag()
     
@@ -98,9 +99,41 @@ public final class DDIPCountDownTimer {
         
         let components = calendar.dateComponents([.hour, .minute, .second], from: usageDate)
         
+        guard isValidComponents(
+            hour: components.hour,
+            minute: components.minute,
+            second: components.second
+        )
+        else {
+            invalidDate.accept(Void())
+            disposeBag = DisposeBag()
+            return
+        }
+        
         hour.accept(components.hour)
         minute.accept(components.minute)
         second.accept(components.second)
+    }
+    
+    private func isValidComponents(hour: Int?, minute: Int?, second: Int?) -> Bool {
+        guard
+            let hour = hour,
+            let minute = minute,
+            let second = second,
+            isValidTime(hour: hour, minute: minute, second: second)
+        else {
+            return false
+        }
+        
+        return true
+    }
+    
+    private func isValidTime(hour: Int, minute: Int, second: Int) -> Bool {
+        if hour == .zero, minute == .zero, second == .zero {
+            return false
+        } else {
+            return true
+        }
     }
 }
 


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve #137


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* 홈의 마감임박 카드와 응모하기 화면의 타이머의 시간이 0이 되었을때의 처리를 추가하였습니다.
* 타이머는 시, 분, 초가 모두 0이 되었을 때 이벤트를 방출합니다.
* a64b8b582b6803faeca9afc69bb7e050e66a480c 커밋에서 등록하기 API를 수정하였습니다.
* https://github.com/mash-up-kr/GGiriGGiri_iOS/pull/154/commits/9324aa0fe425f101c337b58b96bcb93e4e461a10 커밋에서 DateFormat Type의 case를 추가하였습니다.



### 미리보기
<!-- 작업 전/후 스크린샷으로 표현하기 어려울 경우 영상을 첨부합니다. -->

작업 후
<!-- 영상 -->

https://user-images.githubusercontent.com/39300449/184880757-47414fbc-fe48-46eb-9a75-b410b69a5e3e.mov


