### PR TITLE
[DA] 이미지 분석단계 보여지는 방식 변경

### DIFF
--- a/Projects/App/Sources/Common/Extension/UIViewController+.swift
+++ b/Projects/App/Sources/Common/Extension/UIViewController+.swift
@@ -9,19 +9,17 @@
 import UIKit
 
 extension UIViewController {
-    
-    func alert(title: String = "알림",
+    func alert(title: String? = nil,
                message: String,
                okTitle: String = "확인",
                cancelHandler: ((UIAlertAction) -> Void)? = nil,
                okHandler: ((UIAlertAction) -> Void)? = nil) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        
+
         if let _ = cancelHandler {
             let cancelAction = UIAlertAction(title: "취소", style: .cancel)
             alert.addAction(cancelAction)
         }
-        
         let okAction = UIAlertAction(title: okTitle, style: .default, handler: okHandler)
         alert.addAction(okAction)
         

--- a/Projects/App/Sources/Common/View/ToastView.swift
+++ b/Projects/App/Sources/Common/View/ToastView.swift
@@ -12,7 +12,7 @@ import DesignSystem
 import SnapKit
 
 final class ToastView {
-    private let toastView = DDIPToastView()
+    private let toastView = DDIPToastView(.result)
     private let wrapperView = UIView()
     private let dimView = UIView()
 

--- a/Projects/App/Sources/Main/MainViewController.swift
+++ b/Projects/App/Sources/Main/MainViewController.swift
@@ -31,7 +31,7 @@ final class MainViewController: BaseViewController<MainViewModelProtocol> {
     private let toastView = ToastView()
     private let couponIndicatorToastView = DDIPToastView(.imageCheck)
 
-    lazy var activityIndicator: UIActivityIndicatorView = {
+    private lazy var activityIndicator: UIActivityIndicatorView = {
         let activityIndicator = UIActivityIndicatorView()
         activityIndicator.transform = CGAffineTransform.init(scaleX: 3, y: 3)
 
@@ -185,8 +185,6 @@ extension MainViewController {
 
     private func setToastView() {
         couponIndicatorToastView.setDescriptionLabel("쿠폰 이미지 분석 중이에요!\n 잠시만 기다려주세요!")
-        couponIndicatorToastView.translatesAutoresizingMaskIntoConstraints = false
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
 
         self.view.addSubview(couponIndicatorToastView)
         couponIndicatorToastView.addSubview(activityIndicator)

--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -7,8 +7,9 @@
 //
 
 import PhotosUI
-import UIKit
+import Foundation
 
+import DesignSystem
 import RxRelay
 import RxSwift
 
@@ -20,16 +21,18 @@ protocol MainViewModelProtocol {
     var present: ((UIViewController) -> ())? { get set }
     var push: ((UIViewController) -> ())? { get set }
     var applyToast: PublishRelay<Bool> { get }
-    
     var mainDataSource: MainCollectionViewDataSource { get }
     var mainDelegate: MainCollectionViewDelegate { get }
+
+    var toastRequestRelay: PublishRelay<Void> { get }
+    var OCRRequestRelay: BehaviorRelay<SprinkleInformation?> { get }
     
     var deadlineListUpdated: PublishRelay<Void> { get }
     var categoryListUpdated: PublishRelay<Void> { get }
     var gifticonListUpdated: PublishRelay<Void> { get }
     
     var isDeadlineDataExist: Bool { get }
-    
+
     func presentPhotoPicker()
     func requestPHPhotoLibraryAuthorization()
     func handleAuthorizationStatus(with authorizationStatus: PHAuthorizationStatus)
@@ -38,17 +41,20 @@ protocol MainViewModelProtocol {
 
 /// ViewModelProtocol 구현
 final class MainViewModel: MainViewModelProtocol {
-    
     private let disposeBag = DisposeBag()
     private let gifticonService: GifticonService
     private let categoryRepository: CategoryRepositoryLogic
     private let OCRRepository: OCRRepositoryLogic
-   
+
     var alert: Alert? = nil
     var present: ((UIViewController) -> ())? = nil
     var push: ((UIViewController) -> ())? = nil
     let applyToast = PublishRelay<Bool>()
-    
+    var toastRequestRelay = PublishRelay<Void>()
+    var OCRRequestRelay: BehaviorRelay<SprinkleInformation?> {
+        return OCRRepository.sprinkleInformation
+    }
+
     let mainDataSource = MainCollectionViewDataSource()
     lazy var mainDelegate: MainCollectionViewDelegate = {
         let delegate = MainCollectionViewDelegate()
@@ -99,7 +105,8 @@ final class MainViewModel: MainViewModelProtocol {
                 self?.deadlineListUpdated.accept(Void())
             } onFailure: { error in
                 print(error.localizedDescription)
-            }.disposed(by: disposeBag)
+            }
+            .disposed(by: disposeBag)
     }
     
     private func category() {
@@ -122,7 +129,8 @@ final class MainViewModel: MainViewModelProtocol {
                 self?.gifticonListUpdated.accept(Void())
             } onFailure: { error in
                 print(error.localizedDescription)
-            }.disposed(by: disposeBag)
+            }
+            .disposed(by: disposeBag)
     }
     
     private func apply(gifticonId: Int) {
@@ -178,30 +186,12 @@ extension MainViewModel {
         
         handleAuthorizationStatus(with: authorizationStatus)
     }
-    
 }
 
 // MARK: - Private Method
 
 extension MainViewModel {
     private func bind() {
-        OCRRepository.sprinkleInformation
-            .skip(1)
-            .subscribe(onNext: { [weak self] in
-                if let sprinkleInformation = $0 {
-                    self?.routeToRegisterViewController(sprinkleInformation)
-                } else {
-                    self?.alert?(
-                        "쿠폰 정보 생성 실패",
-                        "쿠폰번호를 가져오는 데 실패했습니다.\n더 쉬운 쿠폰사용을 위해 바코드 또는 쿠폰 번호가 잘 보이는 이미지로 다시 시도해주세요!",
-                        nil,
-                        nil,
-                        nil
-                    )
-                }
-            })
-            .disposed(by: disposeBag)
-        
         mainDataSource.didTapDeadLineApplyButton
             .subscribe(onNext: { [weak self] in
                 self?.apply(gifticonId: $0)
@@ -211,19 +201,6 @@ extension MainViewModel {
     
     private func requestOCR(_ image: UIImage) {
         OCRRepository.request(image)
-    }
-    
-    private func routeToRegisterViewController(_ information: SprinkleInformation) {
-        alert?(nil, "쿠폰 이미지 분석 완료!", nil, nil, { [weak self] _ in
-            let viewModel = RegisterGifticonViewModel(
-                network: Network(),
-                categoryRepository: CategoryRepository(CategoryService(network: Network())),
-                information: information
-            )
-            let registerGifticonViewController = RegisterGifticonViewController(viewModel)
-            registerGifticonViewController.modalPresentationStyle = .fullScreen
-            self?.present?(registerGifticonViewController)
-        })
     }
 }
 
@@ -238,6 +215,7 @@ extension MainViewModel: PHPickerViewControllerDelegate {
                     return
                 }
                 self?.requestOCR(image)
+                self?.toastRequestRelay.accept(())
             }
         }
         picker.dismiss(animated: true)

--- a/Projects/App/Sources/Result/ResultViewController.swift
+++ b/Projects/App/Sources/Result/ResultViewController.swift
@@ -24,7 +24,7 @@ final class ResultViewController: BaseViewController<ResultViewModelProtocol> {
     }()
     
     private let resultView = ResultView()
-    private let toastView = DDIPToastView()
+    private let toastView = DDIPToastView(.result)
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Projects/DesignSystem/Sources/Component/ToastView/DDIPToastView.swift
+++ b/Projects/DesignSystem/Sources/Component/ToastView/DDIPToastView.swift
@@ -9,6 +9,13 @@
 import UIKit
 
 public class DDIPToastView: UIView, AddViewsable {
+    public enum ToastType {
+        case result
+        case imageCheck
+    }
+
+    private let type: ToastType
+
     public enum ToastViewOptions {
         case save, saveFail, register, registerFail, apply, applyMyGifticonFail, networkFail
 
@@ -66,10 +73,26 @@ public class DDIPToastView: UIView, AddViewsable {
         fatalError("init(coder:) has not been implemented")
     }
     
-    public init() {
+    public init(_ toastType: ToastType) {
+        self.type = toastType
         super.init(frame: .zero)
         setView()
         setAttribute()
+        updateFromToastStatus()
+    }
+
+    private func updateFromToastStatus() {
+        switch type {
+        case .result:
+            titleLabel.isHidden = false
+            iconImageView.isHidden = false
+            descriptionLabel.isHidden = false
+        case .imageCheck:
+            titleLabel.removeFromSuperview()
+            iconImageView.removeFromSuperview()
+            descriptionLabel.isHidden = false
+
+        }
     }
 
     private func setView() {


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : #153 

# 변경사항
이미지 분석 단계에서 모달 형식 -> 토스트 뷰 형식으로 변경

## 작업 내용
- indicator 토스트뷰 구현
- OCR 요청 후 응답오는 시간 동안 indicator 토스트뷰 띄우도록 변경
- ViewModel에서 ViewController 역할인 부분 일부 이동
- 타입에 따라 다른 toastView 띄우도록 로직 변경
- 
### 스크린샷


쿠폰 성공| 쿠폰 실패
---|---
![쿠폰성공](https://user-images.githubusercontent.com/52434820/185056896-eecf7f54-57a6-40c1-8603-fbe749881748.gif)|![쿠폰실패](https://user-images.githubusercontent.com/52434820/185057032-45c2a8ef-9845-4830-b107-2692c9270d6a.gif)
