### PR TITLE
[DA] 마감임박 기프티콘 타이머 적용

### DIFF
--- a/Projects/App/Sources/Apply/ApplyViewController.swift
+++ b/Projects/App/Sources/Apply/ApplyViewController.swift
@@ -107,6 +107,7 @@ final class ApplyViewController: BaseViewController<ApplyViewModelProtocol> {
             .disposed(by: disposeBag)
         
         applyGifticonView.countdownTimeOver
+            .skip(1)
             .subscribe(onNext: { [weak self] in
                 self?.alert(
                     title: "응모 마감",

--- a/Projects/App/Sources/Driver/Repository/OCRRepository.swift
+++ b/Projects/App/Sources/Driver/Repository/OCRRepository.swift
@@ -42,6 +42,8 @@ final class OCRRepository: OCRRepositoryLogic {
                         expirationDate: model.expirationDate.format(.yearMonthDay)
                     )
                 )
+            }, onFailure: { [weak self] _ in
+                self?.sprinkleInformation.accept(nil)
             })
             .disposed(by: disposeBag)
     }

--- a/Projects/App/Sources/Main/MainViewController.swift
+++ b/Projects/App/Sources/Main/MainViewController.swift
@@ -66,6 +66,7 @@ final class MainViewController: BaseViewController<MainViewModelProtocol> {
             .disposed(by: disposeBag)
 
         viewModel.OCRRequestRelay
+            .skip(1)
             .subscribe(onNext: { [weak self] sprinkleInformation in
                 self?.dismissActivityIndicator()
                 if let sprinkleInformation = sprinkleInformation {

--- a/Projects/App/Sources/Main/View/GifticonDeadLineCollectionViewCell.swift
+++ b/Projects/App/Sources/Main/View/GifticonDeadLineCollectionViewCell.swift
@@ -82,6 +82,8 @@ final class GifticonDeadLineCollectionViewCell: UICollectionViewCell {
     }
     
     func configure(with data: GifticonCard) {
+        bind()
+        
         gifticonId = data.gifticonInfo.id
         cardView.update(
             style: .init(

--- a/Projects/App/Sources/Main/View/GifticonDeadLineCollectionViewCell.swift
+++ b/Projects/App/Sources/Main/View/GifticonDeadLineCollectionViewCell.swift
@@ -89,7 +89,6 @@ final class GifticonDeadLineCollectionViewCell: UICollectionViewCell {
                 brand: data.gifticonInfo.brand,
                 name: data.gifticonInfo.name,
                 expirationDate: data.gifticonInfo.expirationDate,
-                // TODO: 서버에서 받은 카테고리 데이터에 따라 이미지 표시해야함
                 iconImage: data.gifticonInfo.category.assetName
             )
         )

--- a/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineCardView.swift
+++ b/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineCardView.swift
@@ -22,13 +22,13 @@ public class DDIPDeadlineCardView: UIView, AddViewsable {
     private let expirationLabel = UILabel()
     private let dashedLine = DashedLine()
     
-    private let firstTimeView = DDIPTimeView(displayType: .minute)
-    private let secondTimeView = DDIPTimeView(displayType: .minute)
     private let firstMinuteView = DDIPTimeView(displayType: .minute)
-    private let secondMinuteView = DDIPTimeView(displayType: .minute)
+    private let lastMinuteView = DDIPTimeView(displayType: .minute)
+    private let firstSecondView = DDIPTimeView(displayType: .minute)
+    private let lastSecondView = DDIPTimeView(displayType: .minute)
     
-    private let timer = DDIPCountDownTimer(.minute)
-    private let disposeBag = DisposeBag()
+    private let timer = DDIPCountDownTimer(.second)
+    private var disposeBag = DisposeBag()
     
     public let buttonTapEvent = PublishRelay<Void>()
     public let countdownTimeOver = PublishRelay<Void>()
@@ -91,10 +91,10 @@ public class DDIPDeadlineCardView: UIView, AddViewsable {
     }
     
     private func setAttribute() {        
-        firstTimeView.numberLabel.textColor = .designSystem(.neutralBlack)
-        secondTimeView.numberLabel.textColor = .designSystem(.neutralBlack)
-        firstMinuteView.numberLabel.textColor = .designSystem(.dangerRaspberry)
-        secondMinuteView.numberLabel.textColor = .designSystem(.dangerRaspberry)
+        firstMinuteView.numberLabel.textColor = .designSystem(.neutralBlack)
+        lastMinuteView.numberLabel.textColor = .designSystem(.neutralBlack)
+        firstSecondView.numberLabel.textColor = .designSystem(.dangerRaspberry)
+        lastSecondView.numberLabel.textColor = .designSystem(.dangerRaspberry)
         brandLabel.textColor = .designSystem(.neutralBlack)
         nameLabel.textColor = .designSystem(.neutralBlack)
         expirationLabel.textColor = .designSystem(.neutralGray500)
@@ -105,16 +105,26 @@ public class DDIPDeadlineCardView: UIView, AddViewsable {
         nameLabel.font = .designSystem(.pretendard, family: .bold, size: ._18)
         brandLabel.font = .designSystem(.pretendard, family: .regular, size: ._12)
         expirationLabel.font = .designSystem(.pretendard, family: .regular, size: ._12)
-        firstTimeView.numberLabel.font = .designSystem(.chakrapeth, family: .bold, size: ._20)
-        secondTimeView.numberLabel.font = .designSystem(.chakrapeth, family: .bold, size: ._20)
         firstMinuteView.numberLabel.font = .designSystem(.chakrapeth, family: .bold, size: ._20)
-        secondMinuteView.numberLabel.font = .designSystem(.chakrapeth, family: .bold, size: ._20)
+        lastMinuteView.numberLabel.font = .designSystem(.chakrapeth, family: .bold, size: ._20)
+        firstSecondView.numberLabel.font = .designSystem(.chakrapeth, family: .bold, size: ._20)
+        lastSecondView.numberLabel.font = .designSystem(.chakrapeth, family: .bold, size: ._20)
     }
     
     private func setView() {
         self.addSubViews([timeStackView, imageIcon, applyViewer, CTAButton, infoStackView, dashedLine, semiCircleSpaceLeftView, semiCircleSpaceRightView])
-        infoStackView.addArrangedSubviews(brandLabel, nameLabel, expirationLabel)
-        timeStackView.addArrangedSubviews(firstTimeView, secondTimeView, numberLabel, firstMinuteView, secondMinuteView)
+        infoStackView.addArrangedSubviews(
+            brandLabel,
+            nameLabel,
+            expirationLabel
+        )
+        timeStackView.addArrangedSubviews(
+            firstMinuteView,
+            lastMinuteView,
+            numberLabel,
+            firstSecondView,
+            lastSecondView
+        )
     }
     
     private func setValue() {
@@ -181,19 +191,19 @@ public class DDIPDeadlineCardView: UIView, AddViewsable {
     }
     
     private func bindingTimer() {
-        timer.hour
-            .distinctUntilChanged()
-            .subscribe(onNext: { [weak self] in
-                guard let hour = $0 else { return }
-                self?.update(hour: hour)
-            })
-            .disposed(by: disposeBag)
-        
         timer.minute
             .distinctUntilChanged()
             .subscribe(onNext: { [weak self] in
                 guard let minute = $0 else { return }
                 self?.update(minute: minute)
+            })
+            .disposed(by: disposeBag)
+        
+        timer.second
+            .distinctUntilChanged()
+            .subscribe(onNext: { [weak self] in
+                guard let second = $0 else { return }
+                self?.update(second: second)
             })
             .disposed(by: disposeBag)
         
@@ -203,28 +213,31 @@ public class DDIPDeadlineCardView: UIView, AddViewsable {
             .disposed(by: disposeBag)
     }
     
-    private func update(hour: Int) {
-        firstTimeView.update(text: "\(hour / 10)")
-        secondTimeView.update(text: "\(hour % 10)")
-    }
-    
     private func update(minute: Int) {
         firstMinuteView.update(text: "\(minute / 10)")
-        secondMinuteView.update(text: "\(minute % 10)")
+        lastMinuteView.update(text: "\(minute % 10)")
+    }
+    
+    private func update(second: Int) {
+        firstSecondView.update(text: "\(second / 10)")
+        lastSecondView.update(text: "\(second % 10)")
     }
 }
 
 extension DDIPDeadlineCardView {
-    public func update(countDownDate: Date?) {
-        timer.update(date: countDownDate)
-    }
-    
     public func update(style: DDIPDeadlineViewStyle) {
+        disposeBag = DisposeBag()
+        bind()
+        
         imageIcon.image = .designSystem(style.iconImage)
         nameLabel.text = style.name
         brandLabel.text = style.brand
         expirationLabel.text = "유효기간 : \(style.expirationDate.format(.dotYearMonthDay))"
         update(countDownDate: style.time.fullStringDate())
+    }
+    
+    public func update(countDownDate: Date?) {
+        timer.update(date: countDownDate)
     }
     
     public func update(buttonTitle: String, backgroundColor: DDIPColor) {

--- a/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineCardView.swift
+++ b/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineCardView.swift
@@ -208,7 +208,6 @@ public class DDIPDeadlineCardView: UIView, AddViewsable {
             .disposed(by: disposeBag)
         
         timer.invalidDate
-            .skip(1)
             .bind(to: countdownTimeOver)
             .disposed(by: disposeBag)
     }

--- a/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineViewStyle.swift
+++ b/Projects/DesignSystem/Sources/Component/DeadlineCard/DDIPDeadlineViewStyle.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 public struct DDIPDeadlineViewStyle {
-    public let time: String
-    public let brand: String
-    public let name: String
-    public let expirationDate: String
-    public let iconImage: DDIPAsset.name
+    let time: String
+    let brand: String
+    let name: String
+    let expirationDate: String
+    let iconImage: DDIPAsset.name
     
     public init(
         time: String,

--- a/Projects/DesignSystem/Sources/Component/Extension/Formatter.swift
+++ b/Projects/DesignSystem/Sources/Component/Extension/Formatter.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 struct Formatter {
-    static let date: DateFormatter = {
+    static let shared: DateFormatter = {
         let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier:"ko_KR")
-        
+        dateFormatter.locale = Locale.autoupdatingCurrent
+        dateFormatter.timeZone = .current
         return dateFormatter
     }()
     

--- a/Projects/DesignSystem/Sources/Component/Extension/String+Date+sugar.swift
+++ b/Projects/DesignSystem/Sources/Component/Extension/String+Date+sugar.swift
@@ -19,14 +19,14 @@ extension Date {
     }
 
     func hourString() -> String {
-        Formatter.date.dateFormat = "HH"
-        guard let dateString = Formatter.date.string(for: self) else { return "" }
+        Formatter.shared.dateFormat = "HH"
+        guard let dateString = Formatter.shared.string(for: self) else { return "" }
         return dateString
     }
 
     func fullDateString(_ type: FormatType) -> String {
-        Formatter.date.dateFormat = type.displayName
-        guard let dateString = Formatter.date.string(for: self) else { return "" }
+        Formatter.shared.dateFormat = type.displayName
+        guard let dateString = Formatter.shared.string(for: self) else { return "" }
         return dateString
     }
 }
@@ -46,8 +46,8 @@ extension String {
     public func format(_ type: FormatType) -> String {
         let dateData = fullStringDate(type)
 
-        Formatter.date.dateFormat = type.displayName
-        let dateString = Formatter.date.string(from: dateData)
+        Formatter.shared.dateFormat = type.displayName
+        let dateString = Formatter.shared.string(from: dateData)
 
         return dateString
     }
@@ -56,15 +56,15 @@ extension String {
         var formatString: String {
             switch type {
             case .yearMonthDay, .dashYearMonthDay, .hourMinuteSecond:
-                return "yyyy-MM-dd'T'HH:mm"
+                return "yyyy-MM-dd'T'HH:mm:ss.SSS"
             case .dotYearMonthDay:
-                return "yyyy.MM.dd'T'HH:mm"
+                return "yyyy.MM.dd'T'HH:mm:ss.SSS"
             }
         }
         
-        Formatter.date.dateFormat = formatString
+        Formatter.shared.dateFormat = formatString
 
-        guard let dateData = Formatter.date.date(from: self) else {
+        guard let dateData = Formatter.shared.date(from: self) else {
             return Date()
         }
         return dateData

--- a/Projects/DesignSystem/Sources/CountDownTimer/DDIPCountDownTimer.swift
+++ b/Projects/DesignSystem/Sources/CountDownTimer/DDIPCountDownTimer.swift
@@ -140,14 +140,15 @@ public final class DDIPCountDownTimer {
 extension DDIPCountDownTimer {
     func update(date: Date?) {
         disposeBag = DisposeBag()
-
+  
         guard let date = date else { return }
+        standardDate = date
 
         let components = calendar.dateComponents([.hour, .minute, .second], from: Date(), to: date)
         let calculatedDate = calendar.date(from: components)
 
-        standardDate = calculatedDate
         usageDate = calculatedDate
+        updateDateComponents()
         bind()
     }
 }


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve #145 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* 마감임박 기프티콘에 서버에서 내려준 마감 시간을 기준으로 남은시간을 노출하는 로직 적용
    * 9c318598ed67b6168071610d6b4c2987e74c164b
    * db7a610e6af25521235fa82a5847e5f66aa0421c
    * 60a55af6f315f68604e33493653fc0a70740a923
    * 9a7f8116b492afd3951c3e9840c39f47faa40e35
* 20ba19d08011b8cf6e731b3c520c05452ceace4e 마감임박 기프티콘의 남은시간이 0이 되면 마감임박 기프티콘 정보를 다시 불러오도록 설정

### 미리보기
<!-- 작업 전/후 스크린샷으로 표현하기 어려울 경우 영상을 첨부합니다. -->

작업 후 영상 1

https://user-images.githubusercontent.com/39300449/185583993-5659ffe4-6d3c-4186-9b5e-cc9f20624ba3.mp4


작업 후 영상 2

https://user-images.githubusercontent.com/39300449/185588688-6de0f9f3-d005-4b4a-bbc7-0e44dd407f1c.mp4


