### PR TITLE
[DA] 메인 화면에서 데이터 목록 없을 경우 빈 화면 표시

### DIFF
--- a/Projects/App/Sources/Main/MainCollectionViewDataSource.swift
+++ b/Projects/App/Sources/Main/MainCollectionViewDataSource.swift
@@ -41,6 +41,13 @@ final class MainCollectionViewDataSource: NSObject, UICollectionViewDataSource {
         case .category:
             return categoryData.count
         case .gifticonList:
+            let itemCount = gifticonListData.count
+            if itemCount == 0 {
+                let boxView = GifticonListEmptyView()
+                collectionView.backgroundView = boxView
+            } else {
+                collectionView.backgroundView = nil
+            }
             return gifticonListData.count
         }
     }

--- a/Projects/App/Sources/Main/View/GifticonListEmptyView.swift
+++ b/Projects/App/Sources/Main/View/GifticonListEmptyView.swift
@@ -1,8 +1,8 @@
 //
-//  RegisterBoxView.swift
+//  GifticonListEmptyView.swift
 //  GGiriGGiri
 //
-//  Created by 안상희 on 2022/07/28.
+//  Created by 안상희 on 2022/08/19.
 //  Copyright © 2022 dvHuni. All rights reserved.
 //
 
@@ -11,17 +11,17 @@ import UIKit
 import DesignSystem
 import SnapKit
 
-final class RegisterBoxView: BaseView {
-    
-    private let emptyView = EmptyView()
+final class GifticonListEmptyView: BaseView {
 
+    private let emptyView = EmptyView()
+    
     override func setLayout() {
         super.setLayout()
         
         addSubview(emptyView)
         
         emptyView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(117)
+            $0.top.equalToSuperview().offset(200)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(302)
         }
@@ -32,6 +32,6 @@ final class RegisterBoxView: BaseView {
         
         backgroundColor = .clear
         
-        emptyView.configureEmptyCategory(with: .registered)
+        emptyView.configureEmptyCategory()
     }
 }

--- a/Projects/App/Sources/MyBox/View/ApplyBoxView.swift
+++ b/Projects/App/Sources/MyBox/View/ApplyBoxView.swift
@@ -13,7 +13,7 @@ import SnapKit
 
 final class ApplyBoxView: BaseView {
 
-    private let emptyView = MyBoxEmptyView()
+    private let emptyView = EmptyView()
     
     override func setLayout() {
         super.setLayout()

--- a/Projects/App/Sources/MyBox/View/EmptyView.swift
+++ b/Projects/App/Sources/MyBox/View/EmptyView.swift
@@ -1,5 +1,5 @@
 //
-//  MyBoxEmptyView.swift
+//  EmptyView.swift
 //  GGiriGGiri
 //
 //  Created by 안상희 on 2022/07/28.
@@ -11,7 +11,7 @@ import UIKit
 import DesignSystem
 import SnapKit
 
-final class MyBoxEmptyView: BaseView {
+final class EmptyView: BaseView {
 
     private let imageView: UIImageView = {
         let imageView = UIImageView()
@@ -76,6 +76,11 @@ final class MyBoxEmptyView: BaseView {
             return
         }
         titleMessage.text = "등록한 내역이 없어요"
+        detailMessage.text = "필요없는 기프티콘이 있다면\n지금 바로 등록해볼까요?"
+    }
+    
+    func configureEmptyCategory() {
+        titleMessage.text = "아직 등록되지 않았어요"
         detailMessage.text = "필요없는 기프티콘이 있다면\n지금 바로 등록해볼까요?"
     }
 }


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve https://github.com/mash-up-kr/GGiriGGiri_iOS/issues/163


# 변경사항

## 💻 작업 내용
메인 화면에서 기프티콘 목록이 없을 경우 빈 화면을 표시합니다.


## 📱 스크린샷
<!-- 작업 전/후 UI 수정이 있을 경우 스크린샷을 첨부합니다. -->
작업 전|작업 후
---|---
<img width="563" alt="KakaoTalk_Photo_2022-08-19-22-08-30-1" src="https://user-images.githubusercontent.com/95578975/185625518-24cdb16c-f825-46b7-9fae-620587896ad3.jpeg">)|<img width="563" alt="KakaoTalk_Photo_2022-08-19-22-08-30-1" src="https://user-images.githubusercontent.com/95578975/185625363-5d7b544c-ab44-48d1-80c2-45b6804db4d0.png">
