### PR TITLE
[DA] QA 이슈 대응

### DIFF
--- a/Projects/App/Sources/MyBox/View/MyBoxCollectionViewCell.swift
+++ b/Projects/App/Sources/MyBox/View/MyBoxCollectionViewCell.swift
@@ -54,7 +54,7 @@ final class MyBoxCollectionViewCell: UICollectionViewCell {
         let section = CollectionViewLayoutManager.configureSection(with: group,
                                                                    contentInsets: .init(top: .zero,
                                                                                         leading: 16,
-                                                                                        bottom: .zero,
+                                                                                        bottom: 32,
                                                                                         trailing: 16),
                                                                    scrollingBehavior: nil,
                                                                    header: nil)

--- a/Projects/App/Sources/Register/View/RegisterGifticonView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonView.swift
@@ -105,7 +105,10 @@ extension RegisterGifticonView {
     func updateInformation(_ information: SprinkleInformation) {
         gifticonInfoView.update(brandName: information.brandName)
         gifticonInfoView.update(productName: information.productName)
-        gifticonInfoView.update(expirationDate: information.expirationDate)
+        
+        if let expirationDate = information.expirationDate, expirationDate.count == 8 {
+            gifticonInfoView.update(expirationDate: information.expirationDate)
+        }
     }
 }
 

--- a/Projects/App/Sources/Usecase/SprinkleInformation.swift
+++ b/Projects/App/Sources/Usecase/SprinkleInformation.swift
@@ -29,7 +29,7 @@ struct SprinkleInformation {
         self.image = image
         self.brandName = brandName
         self.productName = productName
-        self.expirationDate = expirationDate.format(.yearMonthDay)
+        self.expirationDate = expirationDate
     }
     
     mutating

--- a/Projects/DesignSystem/Sources/Component/Extension/String+Date+sugar.swift
+++ b/Projects/DesignSystem/Sources/Component/Extension/String+Date+sugar.swift
@@ -33,7 +33,7 @@ extension Date {
 
 extension String {
     public enum FormatType: String {
-        case yearMonthDay = "YYYYMMDD"
+        case yearMonthDay = "YYYYMMdd"
         case dashYearMonthDay = "YYYY-MM-dd"
         case dotYearMonthDay = "YYYY.MM.dd"
         case hourMinuteSecond = "HH:mm:SS"


### PR DESCRIPTION
# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* 99503f63d3d6ddbe3d23681cecc0430c7ad90ae8 커밋에서 OCR의 유효기간이 8자리일 때만 인풋에 자동입력되도록 수정하였습니다.
* 6ebc09a90998a1f2ee0360706a052c2621e3e67f 마이박스 화면의 쿠폰리스트의 inset을 수정하였습니다.
* https://github.com/mash-up-kr/GGiriGGiri_iOS/pull/170/commits/3d0955b1a4f8307ed891eac37d2039a1c5cdc2bb 유효기간 인풋에 유효기간이 올바르게 표현되도록 했습니다.
