### PR TITLE
[DA] OCR 에러 케이스 추가 및 로직 변경

### DIFF
--- a/Projects/App/Sources/Driver/Networking/Networking.swift
+++ b/Projects/App/Sources/Driver/Networking/Networking.swift
@@ -82,7 +82,9 @@ final class Network: Networking {
                     },
                     to: endpoint,
                     headers: model.headers
-                )
+                ) {
+                    $0.timeoutInterval = 10
+                }
                 .response{ [single] response in
                     if let error = response.error {
                         single(.failure(NetworkingError.response(error)))

--- a/Projects/App/Sources/Driver/Repository/OCRRepository.swift
+++ b/Projects/App/Sources/Driver/Repository/OCRRepository.swift
@@ -14,6 +14,7 @@ import RxSwift
 enum ResponseError: String {
     case size
     case type
+    case network
     case `default`
 
     var info: (toastTitle: String, toastDescription: String) {
@@ -22,6 +23,8 @@ enum ResponseError: String {
             return ("이미지 가져오기 실패", "용량이 너무 커요.\n다시 한번 시도해주세요!")
         case .type:
             return ("이미지 가져오기 실패", "등록할 수 없는 이미지 포맷이에요.\n이미지의 포맷(jpg,png 등)을 확인해주세요!")
+        case .network:
+            return ("네트워크 오류", "네트워크가 원활하지 않아요.\n네트워크가 잘 연결되어있는지 확인해주세요!")
         case .default:
             return ("", "")
         }
@@ -68,6 +71,8 @@ final class OCRRepository: OCRRepositoryLogic {
                 default:
                     self?.sprinkleInformation.accept((nil, .size))
                 }
+            }, onFailure: { [weak self] _ in
+                self?.sprinkleInformation.accept((nil, .network))
             })
             .disposed(by: disposeBag)
     }

--- a/Projects/App/Sources/Driver/Repository/OCRRepository.swift
+++ b/Projects/App/Sources/Driver/Repository/OCRRepository.swift
@@ -11,8 +11,25 @@ import UIKit
 import RxRelay
 import RxSwift
 
+enum ResponseError: String {
+    case size
+    case type
+    case `default`
+
+    var info: (toastTitle: String, toastDescription: String) {
+        switch self {
+        case .size:
+            return ("이미지 가져오기 실패", "용량이 너무 커요.\n다시 한번 시도해주세요!")
+        case .type:
+            return ("이미지 가져오기 실패", "등록할 수 없는 이미지 포맷이에요.\n이미지의 포맷(jpg,png 등)을 확인해주세요!")
+        case .default:
+            return ("", "")
+        }
+    }
+}
+
 protocol OCRRepositoryLogic {
-    var sprinkleInformation: BehaviorRelay<SprinkleInformation?> { get }
+    var sprinkleInformation: BehaviorRelay<(SprinkleInformation?, ResponseError)> { get }
     
     func request(_ image: UIImage)
 }
@@ -21,7 +38,7 @@ final class OCRRepository: OCRRepositoryLogic {
     private let disposeBag = DisposeBag()
     private let OCRService: OCRServiceLogic
     
-    var sprinkleInformation = BehaviorRelay<SprinkleInformation?>(value: nil)
+    var sprinkleInformation = BehaviorRelay<(SprinkleInformation?, ResponseError)>(value: (nil, .default))
     
     init(_ OCRService: OCRServiceLogic) {
         self.OCRService = OCRService
@@ -30,20 +47,27 @@ final class OCRRepository: OCRRepositoryLogic {
     func request(_ image: UIImage) {
         OCRService.request(OCRRequestModel(image: image))
             .subscribe(onSuccess: { [weak self] in
-                guard let model = $0.data else {
-                    self?.sprinkleInformation.accept(nil)
-                    return
+                switch $0.code {
+                case "S001":
+                    self?.sprinkleInformation.accept((
+                        SprinkleInformation(
+                            image: image,
+                            brandName: $0.data?.brandName ?? "",
+                            productName: $0.data?.productName ?? "",
+                            expirationDate: $0.data?.expirationDate.format(.yearMonthDay) ?? ""
+                        ), .default
+                    ))
+                case "C002":
+                    self?.sprinkleInformation.accept((
+                        SprinkleInformation(
+                            image: image
+                        ), .default
+                    ))
+                case "F003":
+                    self?.sprinkleInformation.accept((nil, .type))
+                default:
+                    self?.sprinkleInformation.accept((nil, .size))
                 }
-                self?.sprinkleInformation.accept(
-                    SprinkleInformation(
-                        image: image,
-                        brandName: model.brandName,
-                        productName: model.productName,
-                        expirationDate: model.expirationDate.format(.yearMonthDay)
-                    )
-                )
-            }, onFailure: { [weak self] _ in
-                self?.sprinkleInformation.accept(nil)
             })
             .disposed(by: disposeBag)
     }

--- a/Projects/App/Sources/Main/MainViewController.swift
+++ b/Projects/App/Sources/Main/MainViewController.swift
@@ -74,12 +74,12 @@ final class MainViewController: BaseViewController<MainViewModelProtocol> {
             .skip(1)
             .subscribe(onNext: { [weak self] sprinkleInformation in
                 self?.dismissActivityIndicator()
-                if let sprinkleInformation = sprinkleInformation {
+                if let sprinkleInformation = sprinkleInformation.0 {
                     self?.showRegisterView(information: sprinkleInformation)
                 } else {
                     self?.viewModel.alert?(
-                        "쿠폰 정보 생성 실패",
-                        "쿠폰번호를 가져오는 데 실패했습니다.\n더 쉬운 쿠폰사용을 위해 바코드 또는 쿠폰 번호가 잘 보이는 이미지로 다시 시도해주세요!",
+                        sprinkleInformation.1.info.toastTitle,
+                        sprinkleInformation.1.info.toastDescription,
                         nil,
                         nil,
                         nil
@@ -217,7 +217,7 @@ extension MainViewController {
     }
 
     private func setToastView() {
-        couponIndicatorToastView.setDescriptionLabel("쿠폰 이미지 분석 중이에요!\n 잠시만 기다려주세요!")
+        couponIndicatorToastView.setDescriptionLabel("잠시만 기다려주세요!")
 
         self.view.addSubview(couponIndicatorToastView)
         couponIndicatorToastView.addSubview(activityIndicator)

--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -26,7 +26,7 @@ protocol MainViewModelProtocol {
     var mainDelegate: MainCollectionViewDelegate { get }
 
     var toastRequestRelay: PublishRelay<Void> { get }
-    var OCRRequestRelay: BehaviorRelay<SprinkleInformation?> { get }
+    var OCRRequestRelay: BehaviorRelay<(SprinkleInformation?, ResponseError)> { get }
     
     var deadlineListUpdated: PublishRelay<Void> { get }
     var categoryListUpdated: PublishRelay<Void> { get }
@@ -85,7 +85,7 @@ final class MainViewModel: MainViewModelProtocol {
     }()
     
     var toastRequestRelay = PublishRelay<Void>()
-    var OCRRequestRelay: BehaviorRelay<SprinkleInformation?> {
+    var OCRRequestRelay: BehaviorRelay<(SprinkleInformation?, ResponseError)> {
         return OCRRepository.sprinkleInformation
     }
     


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : #176 

## 작업 내용
- OCR 용량 컸을 때 에러 처리
- OCR 포맷 안맞을 때 에러 처리 (용량이 크고 포맷이 안맞을 경우 용량이 큰 에러로 처리)
- OCR 네트워크 통신 실패 시 에러 처리

포맷 안맞고 용량 작은 사진을 찾지 못해서 올리지 못했습니다

### 스크린샷
- OCR 용량 컸을 때 에러 처리

<img src ="https://user-images.githubusercontent.com/52434820/185757244-d75dc301-c4db-4151-9c30-59dc1b1bccbd.PNG" width ="400">

- OCR 네트워크 통신 실패 시 에러 처리
<img src ="https://user-images.githubusercontent.com/52434820/185757252-70cff868-d43c-4f6f-aeb6-a73477bbd319.PNG" width ="400">

