### PR TITLE
[D2]동일 카테고리 선택시 이벤트 미 방출

### DIFF
--- a/Projects/App/Sources/Main/MainCollectionViewDelegate.swift
+++ b/Projects/App/Sources/Main/MainCollectionViewDelegate.swift
@@ -39,6 +39,7 @@ final class MainCollectionViewDelegate: NSObject, UICollectionViewDelegate {
             // 셀 선택 상태 변경
             cell.updateButton(isSelected: true)
             
+            guard selectedCategoryIndexPath != indexPath else { return }
             selectedCategoryIndexPath = indexPath
             collectionViewCellDelegate?.categoryCellTapped(indexPath: indexPath)
         case .gifticonList:


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve #185


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* dataSource가 가지고있는 이미 선택된 category 에 대한 indexPath 가 동일하지 않을 때 (다른 카테고리 일 때) delegate method를 호출하도록 변경하였습니다.

### 미리보기
<!-- 작업 전/후 스크린샷으로 표현하기 어려울 경우 영상을 첨부합니다. -->

### 작업 전
<!-- 영상 -->


https://user-images.githubusercontent.com/39300449/186179748-fc84aba2-1cc7-44e7-9c0a-6e49ef0312d9.mov



### 작업 후
<!-- 영상 -->

https://user-images.githubusercontent.com/39300449/186179527-6976322f-5492-4328-8da9-eb0edc508400.mov


