### PR TITLE
[DA] 마감임박 타이머 만료시 이슈 대응

### DIFF
--- a/Projects/App/Sources/Common/SplashViewModel.swift
+++ b/Projects/App/Sources/Common/SplashViewModel.swift
@@ -44,19 +44,11 @@ final class SplashViewModel: SplashViewModelProtocol {
     }
     
     private func changeRootViewController(deadlineData: Int) {
-        
-        var isDeadlineDataExist = true
-        
-        if deadlineData == 0 {
-            isDeadlineDataExist = false
-        }
-        
         let rootViewController = MainViewController(
             MainViewModel(
                 network: Network(),
                 repository: CategoryRepository(CategoryService(network: Network())),
-                OCRRepository: OCRRepository(OCRService(network: Network())),
-                deadlineDataExist: isDeadlineDataExist
+                OCRRepository: OCRRepository(OCRService(network: Network()))
             ))
         
         let navigationController = UINavigationController(rootViewController: rootViewController)

--- a/Projects/App/Sources/Main/MainCollectionViewDataSource.swift
+++ b/Projects/App/Sources/Main/MainCollectionViewDataSource.swift
@@ -24,7 +24,7 @@ final class MainCollectionViewDataSource: NSObject, UICollectionViewDataSource {
     var didDeadLineCountdownTimeOver = PublishRelay<Void>()
     var selectedCategoryIndexPath: IndexPath? = nil
     
-    private let disposeBag = DisposeBag()
+    private var deadLineDisposeBag = DisposeBag()
     
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         // TODO: 마감임박 데이터 없을 때의 경우 처리 필요
@@ -67,7 +67,7 @@ final class MainCollectionViewDataSource: NSObject, UICollectionViewDataSource {
             cell.gifticonApplyButtonDelegate = self
             cell.countdownTimeOver
                 .bind(to: didDeadLineCountdownTimeOver)
-                .disposed(by: disposeBag)
+                .disposed(by: deadLineDisposeBag)
             return cell
         case .category:
             guard let cell = collectionView.dequeReusableCell(CategoryCollectionViewCell.self,
@@ -112,6 +112,7 @@ final class MainCollectionViewDataSource: NSObject, UICollectionViewDataSource {
 extension MainCollectionViewDataSource {
     func updateDeadLineData(_ list: [GifticonCard]) {
         deadLineData = list
+        deadLineDisposeBag = DisposeBag()
     }
     
     func updateCategoryData(_ list: [Category]) {

--- a/Projects/App/Sources/Main/MainViewController.swift
+++ b/Projects/App/Sources/Main/MainViewController.swift
@@ -144,8 +144,6 @@ final class MainViewController: BaseViewController<MainViewModelProtocol> {
         mainView.configureDataSource(viewModel.mainDataSource)
         mainView.configureDelegate(viewModel.mainDelegate)
         
-        mainView.isDeadlineDataExist.accept(viewModel.isDeadlineDataExist.value)
-        
         view.addSubview(mainView)
         mainView.snp.makeConstraints {
             $0.top.equalTo(navigationBar.snp.bottom)

--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -96,17 +96,13 @@ final class MainViewModel: MainViewModelProtocol {
     init(
         network: Networking,
         repository: CategoryRepositoryLogic,
-        OCRRepository: OCRRepositoryLogic,
-        deadlineDataExist: Bool
+        OCRRepository: OCRRepositoryLogic
     ) {
         self.gifticonService = GifticonService(network: network)
         self.categoryRepository = repository
         self.OCRRepository = OCRRepository
-        self.isDeadlineDataExist.accept(deadlineDataExist)
         
-        deadlineInfo()
         category()
-        gifticonList()
         bind()
     }
     

--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -191,7 +191,10 @@ extension MainViewModel {
             })
             .disposed(by: disposeBag)
         
+        // 마감 시간이 지나고 바로 리스트 재요청 시 그대로 남아있는 이슈가 있음
+        // 따라서 delay 500ms를 추가함
         mainDataSource.didDeadLineCountdownTimeOver
+            .delay(.milliseconds(500), scheduler: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in
                 self?.reload()
             })

--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -193,7 +193,7 @@ extension MainViewModel {
         
         mainDataSource.didDeadLineCountdownTimeOver
             .subscribe(onNext: { [weak self] in
-                self?.deadlineInfo()
+                self?.reload()
             })
             .disposed(by: disposeBag)
     }

--- a/Projects/App/Sources/Main/View/MainView.swift
+++ b/Projects/App/Sources/Main/View/MainView.swift
@@ -34,6 +34,8 @@ final class MainView: BaseView {
         backgroundColor = .clear
         
         isDeadlineDataExist
+            .skip(1)
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
             .subscribe(onNext: { [weak self] _ in
                 self?.reloadCollectionViewSection(.deadLine)
             })

--- a/Projects/App/Sources/Usecase/GifticonEntity.swift
+++ b/Projects/App/Sources/Usecase/GifticonEntity.swift
@@ -13,7 +13,9 @@ struct GifticonEntity {
     
     init(_ responseModel: [GifticonResponseModel] = []) {
         gifticonList = responseModel.compactMap({ model in
-            GifticonCard(
+            // 마감 시간이 지난 경우 리스트에 노출되지 않도록 방어
+            guard model.sprinkleAt.fullStringDate().compare(Date()) != .orderedAscending else { return nil }
+            return GifticonCard(
                 sprinkleTime: model.sprinkleAt,
                 gifticonInfo: Gifticon(
                     id: model.sprinkleID,
@@ -22,7 +24,8 @@ struct GifticonEntity {
                     expirationDate: model.expiredAt,
                     category: Category(rawValue: model.category) ?? .all),
                 numberOfParticipants: model.participants,
-                isParticipating: model.participateIn)
+                isParticipating: model.participateIn
+            )
         })
     }
 }


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : #189 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* 마감임박 타이머 만료시 binding 문제로 인한 무수히 많은 reload를 대응하였습니다. 12adf3f5eca9c635aa1870bfe5b7bf3ec32559f9
    * 마감임박 기프티콘 데이터가 새로 셋팅 될 때 마다 disposeBag을 초기화 하여 binding 된 내용을 dispose하였습니다.
* 마감임박 타이머 만료 시 카테고리별 기프티콘 리스트는 새로 받아오지 않아 리스트에 그대로 남아 있는 현상을 대응하였습니다. eef1b222890914a8301b66d369b6075396cdd37d
* 마감임박 타이머 만료 시 API를 새로 요청하지만, 데이터가 그대로 남아 있는 현상을 대응하였습니다. 1bbacd66c438d76fcc05c507d59757804d574aa2
    * 마감 시간이 현재시간보다 지난 경우에는 마감임박 기프티콘 리스트에 추가 하지 않도록 방어코드를 추가했습니다.
    * 그러나 API 재요청시 현재시간보다 미세하게 빨라 리스트에 그대로 노출되는 현상이 발생했습니다.
    * 위 이슈를 해결하기 위해 API 요청 전에 delay를 추가하여 조금 늦게 API를 요청하도록 하여 해결하였습니다.

### 미리보기
<!-- 작업 전/후 스크린샷으로 표현하기 어려울 경우 영상을 첨부합니다. -->

작업 전
<!-- 영상 -->

https://user-images.githubusercontent.com/39300449/186715991-8ebd0f0e-7c49-432c-8a3f-15b93fc7b419.mov



작업 후
<!-- 영상 -->

https://user-images.githubusercontent.com/39300449/186715791-9bc6f46f-9bbb-49eb-b36c-a68d1c0e5292.mov


