### PR TITLE
[DA] 등록 화면 카테고리 선택 버튼 간격 수정

### DIFF
--- a/Projects/App/Sources/Register/View/RegisterGifticonInfoView.swift
+++ b/Projects/App/Sources/Register/View/RegisterGifticonInfoView.swift
@@ -54,10 +54,14 @@ final class RegisterGifticonInfoView: BaseView {
     private func generateCategorySection() -> NSCollectionLayoutSection {
         let item = CollectionViewLayoutManager.configureItem(
             with: CollectionViewConfigureSize(
-                widthDimension: .estimated(10),
+                widthDimension: .estimated(1),
                 heightDimension: .absolute(34)
             )
         )
+        item.edgeSpacing = .init(leading: .none,
+                                 top: .none,
+                                 trailing: .fixed(8),
+                                 bottom: .none)
         
         let group = CollectionViewLayoutManager.configureGroup(
             with: CollectionViewConfigureSize(


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve https://github.com/mash-up-kr/GGiriGGiri_iOS/issues/196

# 변경사항

## 작업 내용
등록 화면 카테고리 선택 버튼 간격을 수정하였습니다.


### 스크린샷
<!-- 작업 전/후 UI 수정이 있을 경우 스크린샷을 첨부합니다. -->
작업 전|작업 후
---|---
![232](https://user-images.githubusercontent.com/95578975/187361269-ab5d306c-95d4-4ea3-ad85-dbec105f0b5c.jpeg)|![11](https://user-images.githubusercontent.com/95578975/187361253-6a21318f-bc3e-4361-b163-5ce127230fcc.jpeg)
