### PR TITLE
[DA] 마감임박 타이머 종료 후 Action delay 추가

### DIFF
--- a/Projects/App/Sources/Main/MainViewModel.swift
+++ b/Projects/App/Sources/Main/MainViewModel.swift
@@ -191,10 +191,11 @@ extension MainViewModel {
             })
             .disposed(by: disposeBag)
         
-        // 마감 시간이 지나고 바로 리스트 재요청 시 그대로 남아있는 이슈가 있음
-        // 따라서 delay 500ms를 추가함
+        /// 마감 시간이 지나고 바로 리스트 재요청 시 그대로 남아있는 이슈가 있음
+        /// 따라서 delay 1초를 추가함
+        /// - Note: https://github.com/mash-up-kr/GGiriGGiri_iOS/issues/199
         mainDataSource.didDeadLineCountdownTimeOver
-            .delay(.milliseconds(500), scheduler: MainScheduler.instance)
+            .delay(.seconds(1), scheduler: MainScheduler.instance)
             .subscribe(onNext: { [weak self] in
                 self?.reload()
             })


### PR DESCRIPTION
# 개요
- 🔗  이슈링크 : resolve #199 


# 변경사항

## 작업 내용
<!-- 작업한 코드/UI에 대한 설명을 작성합니다. -->
* 500ms 로 되어있던 이벤트 delay를 1초로 수정하였습니다.
